### PR TITLE
운동 경기 모집 게시판 백엔드 프로세스 3차 수정

### DIFF
--- a/src/main/java/kr/megaptera/smash/controllers/PostController.java
+++ b/src/main/java/kr/megaptera/smash/controllers/PostController.java
@@ -1,20 +1,107 @@
 package kr.megaptera.smash.controllers;
 
+import kr.megaptera.smash.dtos.ImageDto;
+import kr.megaptera.smash.dtos.MemberDto;
+import kr.megaptera.smash.dtos.PlaceDto;
+import kr.megaptera.smash.dtos.PostThumbnailDto;
 import kr.megaptera.smash.dtos.PostThumbnailsDto;
+import kr.megaptera.smash.dtos.RoleDto;
+import kr.megaptera.smash.dtos.TeamDto;
+import kr.megaptera.smash.models.Image;
+import kr.megaptera.smash.models.Member;
+import kr.megaptera.smash.models.Place;
+import kr.megaptera.smash.models.Post;
+import kr.megaptera.smash.models.Role;
+import kr.megaptera.smash.models.Team;
+import kr.megaptera.smash.models.User;
+import kr.megaptera.smash.services.ImageService;
+import kr.megaptera.smash.services.MemberService;
+import kr.megaptera.smash.services.PlaceService;
 import kr.megaptera.smash.services.PostService;
+import kr.megaptera.smash.services.RoleService;
+import kr.megaptera.smash.services.TeamService;
+import kr.megaptera.smash.services.UserService;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 public class PostController {
   private final PostService postService;
+  private final UserService userService;
+  private final ImageService imageService;
+  private final TeamService teamService;
+  private final RoleService roleService;
+  private final MemberService memberService;
+  private final PlaceService placeService;
 
-  public PostController(PostService postService) {
+  public PostController(PostService postService,
+                        UserService userService,
+                        ImageService imageService,
+                        TeamService teamService,
+                        RoleService roleService,
+                        MemberService memberService,
+                        PlaceService placeService) {
     this.postService = postService;
+    this.userService = userService;
+    this.imageService = imageService;
+    this.teamService = teamService;
+    this.roleService = roleService;
+    this.memberService = memberService;
+    this.placeService = placeService;
   }
 
   @GetMapping("/posts/list")
   public PostThumbnailsDto posts() {
-    return postService.posts();
+    List<Post> posts = postService.posts();
+    List<Team> teams = teamService.teams();
+    List<Role> roles = roleService.roles();
+    List<Member> members = memberService.members();
+    List<Place> places = placeService.placesInPosts(posts);
+
+    List<PostThumbnailDto> postThumbnailDtos = posts.stream()
+        .map(post -> {
+          User author = userService.user(post.userId());
+          List<ImageDto> imageDtos
+              = imageService.imagesByPost(post.id()).stream()
+              .map(Image::toDto)
+              .toList();
+          return post.toThumbnailDto(author.name(), imageDtos);
+        })
+        .toList();
+
+    List<TeamDto> teamDtos = teams.stream()
+        .map(team -> {
+          Integer membersCount = memberService.membersCountByTeam(team.id());
+          return team.toDto(membersCount);
+        })
+        .toList();
+
+    List<RoleDto> roleDtos = roles.stream()
+        .map(role -> {
+          Integer participantsCount = memberService.membersCountByRole(role.id());
+          return role.toDto(participantsCount);
+        })
+        .toList();
+
+    List<MemberDto> memberDtos = members.stream()
+        .map(member -> {
+          User participant = userService.user(member.userId());
+          return member.toDto(participant.name(), participant.mannerScore());
+        })
+        .toList();
+
+    List<PlaceDto> placeDtos = places.stream()
+        .map(Place::toDto)
+        .toList();
+
+    return new PostThumbnailsDto(
+        postThumbnailDtos,
+        teamDtos,
+        roleDtos,
+        memberDtos,
+        placeDtos
+    );
   }
 }

--- a/src/main/java/kr/megaptera/smash/dtos/ImageDto.java
+++ b/src/main/java/kr/megaptera/smash/dtos/ImageDto.java
@@ -1,0 +1,34 @@
+package kr.megaptera.smash.dtos;
+
+public class ImageDto {
+  private final Long id;
+
+  private final Long postId;
+
+  private final String url;
+
+  private final Boolean isThumbnailImage;
+
+  public ImageDto(Long id, Long postId, String url, Boolean isThumbnailImage) {
+    this.id = id;
+    this.postId = postId;
+    this.url = url;
+    this.isThumbnailImage = isThumbnailImage;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public Long getPostId() {
+    return postId;
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public Boolean getThumbnailImage() {
+    return isThumbnailImage;
+  }
+}

--- a/src/main/java/kr/megaptera/smash/dtos/MemberDto.java
+++ b/src/main/java/kr/megaptera/smash/dtos/MemberDto.java
@@ -1,0 +1,46 @@
+package kr.megaptera.smash.dtos;
+
+public class MemberDto {
+  private final Long id;
+
+  private final String name;
+
+  private final Long teamId;
+
+  private final Long positionId;
+
+  private final Double mannerScore;
+
+
+  public MemberDto(Long id,
+                   String name,
+                   Long teamId,
+                   Long roleId,
+                   Double mannerScore) {
+    this.id = id;
+    this.name = name;
+    this.teamId = teamId;
+    this.positionId = roleId;
+    this.mannerScore = mannerScore;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Long getTeamId() {
+    return teamId;
+  }
+
+  public Long getPositionId() {
+    return positionId;
+  }
+
+  public Double getMannerScore() {
+    return mannerScore;
+  }
+}

--- a/src/main/java/kr/megaptera/smash/dtos/PlaceDto.java
+++ b/src/main/java/kr/megaptera/smash/dtos/PlaceDto.java
@@ -1,0 +1,27 @@
+package kr.megaptera.smash.dtos;
+
+public class PlaceDto {
+  private final Long id;
+
+  private final Long postId;
+
+  private final String name;
+
+  public PlaceDto(Long id, Long postId, String name) {
+    this.id = id;
+    this.postId = postId;
+    this.name = name;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public Long getPostId() {
+    return postId;
+  }
+
+  public String getName() {
+    return name;
+  }
+}

--- a/src/main/java/kr/megaptera/smash/dtos/PostThumbnailDto.java
+++ b/src/main/java/kr/megaptera/smash/dtos/PostThumbnailDto.java
@@ -1,15 +1,35 @@
 package kr.megaptera.smash.dtos;
 
+import java.util.List;
+
 public class PostThumbnailDto {
   private final Long id;
 
+  private final String postType;
+
   private final String author;
+
+  private final String createdAt;
+
+  private final Integer hits;
+
+  private final List<ImageDto> images;
 
   private final String detail;
 
-  public PostThumbnailDto(Long id, String author, String detail) {
+  public PostThumbnailDto(Long id,
+                          String postType,
+                          String author,
+                          String createdAt,
+                          Integer hits,
+                          List<ImageDto> images,
+                          String detail) {
     this.id = id;
+    this.postType = postType;
     this.author = author;
+    this.createdAt = createdAt;
+    this.hits = hits;
+    this.images = images;
     this.detail = detail;
   }
 
@@ -17,8 +37,24 @@ public class PostThumbnailDto {
     return id;
   }
 
+  public String getPostType() {
+    return postType;
+  }
+
   public String getAuthor() {
     return author;
+  }
+
+  public String getCreatedAt() {
+    return createdAt;
+  }
+
+  public Integer getHits() {
+    return hits;
+  }
+
+  public List<ImageDto> getImages() {
+    return images;
   }
 
   public String getDetail() {

--- a/src/main/java/kr/megaptera/smash/dtos/PostThumbnailsDto.java
+++ b/src/main/java/kr/megaptera/smash/dtos/PostThumbnailsDto.java
@@ -1,7 +1,5 @@
 package kr.megaptera.smash.dtos;
 
-import kr.megaptera.smash.models.Role;
-
 import java.util.List;
 
 public class PostThumbnailsDto {
@@ -11,12 +9,20 @@ public class PostThumbnailsDto {
 
   private final List<RoleDto> positions;
 
+  private final List<MemberDto> members;
+
+  private final List<PlaceDto> places;
+
   public PostThumbnailsDto(List<PostThumbnailDto> posts,
                            List<TeamDto> teams,
-                           List<RoleDto> roles) {
+                           List<RoleDto> positions,
+                           List<MemberDto> members,
+                           List<PlaceDto> places) {
     this.posts = posts;
     this.teams = teams;
-    this.positions = roles;
+    this.positions = positions;
+    this.members = members;
+    this.places = places;
   }
 
   public List<PostThumbnailDto> getPosts() {
@@ -29,5 +35,13 @@ public class PostThumbnailsDto {
 
   public List<RoleDto> getPositions() {
     return positions;
+  }
+
+  public List<MemberDto> getMembers() {
+    return members;
+  }
+
+  public List<PlaceDto> getPlaces() {
+    return places;
   }
 }

--- a/src/main/java/kr/megaptera/smash/dtos/TeamDto.java
+++ b/src/main/java/kr/megaptera/smash/dtos/TeamDto.java
@@ -7,20 +7,44 @@ public class TeamDto {
 
   private final String name;
 
+  private final String exercise;
+
+  private final String exerciseDate;
+
+  private final String exerciseType;
+
+  private final String exerciseLevel;
+
+  private final String exerciseGender;
+
   private final Integer membersCount;
 
   private final Integer targetMembersCount;
 
+  private final Integer cost;
+
   public TeamDto(Long id,
                  Long postId,
                  String name,
+                 String exercise,
+                 String exerciseDate,
+                 String exerciseType,
+                 String exerciseLevel,
+                 String exerciseGender,
                  Integer membersCount,
-                 Integer targetMembersCount) {
+                 Integer targetMembersCount,
+                 Integer cost) {
     this.id = id;
     this.postId = postId;
     this.name = name;
+    this.exercise = exercise;
+    this.exerciseDate = exerciseDate;
+    this.exerciseType = exerciseType;
+    this.exerciseLevel = exerciseLevel;
+    this.exerciseGender = exerciseGender;
     this.membersCount = membersCount;
     this.targetMembersCount = targetMembersCount;
+    this.cost = cost;
   }
 
   public Long getId() {
@@ -35,11 +59,35 @@ public class TeamDto {
     return name;
   }
 
+  public String getExercise() {
+    return exercise;
+  }
+
+  public String getExerciseDate() {
+    return exerciseDate;
+  }
+
+  public String getExerciseType() {
+    return exerciseType;
+  }
+
+  public String getExerciseLevel() {
+    return exerciseLevel;
+  }
+
+  public String getExerciseGender() {
+    return exerciseGender;
+  }
+
   public Integer getMembersCount() {
     return membersCount;
   }
 
   public Integer getTargetMembersCount() {
     return targetMembersCount;
+  }
+
+  public Integer getCost() {
+    return cost;
   }
 }

--- a/src/main/java/kr/megaptera/smash/exceptions/UserNotFound.java
+++ b/src/main/java/kr/megaptera/smash/exceptions/UserNotFound.java
@@ -1,0 +1,7 @@
+package kr.megaptera.smash.exceptions;
+
+public class UserNotFound extends RuntimeException {
+  public UserNotFound() {
+    super("사용자를 찾을 수 없습니다.");
+  }
+}

--- a/src/main/java/kr/megaptera/smash/models/Image.java
+++ b/src/main/java/kr/megaptera/smash/models/Image.java
@@ -1,0 +1,47 @@
+package kr.megaptera.smash.models;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import kr.megaptera.smash.dtos.ImageDto;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+@Entity
+public class Image {
+  @Id
+  @GeneratedValue
+  private Long id;
+
+  private Long postId;
+
+  private String url;
+
+  private Boolean isThumbnailImage;
+
+  public Image() {
+
+  }
+
+  public Image(Long id, Long postId, String url, Boolean isThumbnailImage) {
+    this.id = id;
+    this.postId = postId;
+    this.url = url;
+    this.isThumbnailImage = isThumbnailImage;
+  }
+
+  public String url() {
+    return url;
+  }
+
+  public ImageDto toDto() {
+    return new ImageDto(
+        id,
+        postId,
+        url,
+        isThumbnailImage
+    );
+  }
+}

--- a/src/main/java/kr/megaptera/smash/models/Member.java
+++ b/src/main/java/kr/megaptera/smash/models/Member.java
@@ -1,11 +1,10 @@
 package kr.megaptera.smash.models;
 
+import kr.megaptera.smash.dtos.MemberDto;
+
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToOne;
 
 @Entity
 public class Member {
@@ -13,26 +12,50 @@ public class Member {
   @GeneratedValue
   private Long id;
 
-  @ManyToOne
-  @JoinColumn(name = "TEAM_ID")
-  private Team teamIn;
+  private Long teamId;
 
-  @OneToOne
-  @JoinColumn(name = "PERSON_ID")
-  private User person;
+  private Long roleId;
 
-  @ManyToOne
-  @JoinColumn(name = "POSITION_ID")
-  private Role roleIn;
+  private Long userId;
 
   public Member() {
 
   }
 
-  public Member(Long id, Team teamIn, User person, Role roleIn) {
+  public Member(Long id,
+                Long teamId,
+                Long roleId,
+                Long userId) {
     this.id = id;
-    this.teamIn = teamIn;
-    this.person = person;
-    this.roleIn = roleIn;
+    this.teamId = teamId;
+    this.roleId = roleId;
+    this.userId = userId;
+  }
+
+  public Long id() {
+    return id;
+  }
+
+  public Long teamId() {
+    return teamId;
+  }
+
+  public Long roleId() {
+    return roleId;
+  }
+
+  public Long userId() {
+    return userId;
+  }
+
+  public MemberDto toDto(String name,
+                         Double mannerScore) {
+    return new MemberDto(
+        id,
+        name,
+        teamId,
+        roleId,
+        mannerScore
+    );
   }
 }

--- a/src/main/java/kr/megaptera/smash/models/Place.java
+++ b/src/main/java/kr/megaptera/smash/models/Place.java
@@ -1,0 +1,50 @@
+package kr.megaptera.smash.models;
+
+import kr.megaptera.smash.dtos.PlaceDto;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+public class Place {
+  @Id
+  @GeneratedValue
+  private Long id;
+
+  private Long postId;
+
+  private String name;
+
+  public Place() {
+
+  }
+
+  public Place(Long id,
+               Long postId,
+               String name) {
+    this.id = id;
+    this.postId = postId;
+    this.name = name;
+  }
+
+  public Long id() {
+    return id;
+  }
+
+  public Long postId() {
+    return postId;
+  }
+
+  public String name() {
+    return name;
+  }
+
+  public PlaceDto toDto() {
+    return new PlaceDto(
+        id,
+        postId,
+        name
+    );
+  }
+}

--- a/src/main/java/kr/megaptera/smash/models/Post.java
+++ b/src/main/java/kr/megaptera/smash/models/Post.java
@@ -1,13 +1,14 @@
 package kr.megaptera.smash.models;
 
+import kr.megaptera.smash.dtos.ImageDto;
 import kr.megaptera.smash.dtos.PostThumbnailDto;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Entity
@@ -16,12 +17,17 @@ public class Post {
   @GeneratedValue
   private Long id;
 
-  @OneToMany(mappedBy = "postIn")
-  private List<Team> teamsUnder;
+  private Long userId;
 
-  @ManyToOne
-  @JoinColumn(name = "AUTHOR_ID")
-  private User author;
+  @CreationTimestamp
+  private LocalDateTime createdAt;
+
+  @UpdateTimestamp
+  private LocalDateTime updatedAt;
+
+  private String type;
+
+  private Integer hits;
 
   private String detail;
 
@@ -29,21 +35,57 @@ public class Post {
 
   }
 
-  public Post(Long id) {
+  public Post(Long id,
+              Long userId,
+              String type,
+              Integer hits,
+              String detail) {
     this.id = id;
-  }
-
-  public Post(Long id, User author, String detail) {
-    this.id = id;
-    this.author = author;
+    this.userId = userId;
+    this.type = type;
+    this.hits = hits;
     this.detail = detail;
-  }
-
-  public PostThumbnailDto toThumbnailDto() {
-    return new PostThumbnailDto(id, author.author(), detail);
   }
 
   public Long id() {
     return id;
+  }
+
+  public Long userId() {
+    return userId;
+  }
+
+  public LocalDateTime createdAt() {
+    return createdAt;
+  }
+
+  public String type() {
+    return type;
+  }
+
+  public Integer hits() {
+    return hits;
+  }
+
+  public String detail() {
+    return detail;
+  }
+
+  public String convertDateTime() {
+    return "";
+//    return createdAt.format();
+  }
+
+  public PostThumbnailDto toThumbnailDto(String author,
+                                         List<ImageDto> imageDtos) {
+    return new PostThumbnailDto(
+        id,
+        type,
+        author,
+        convertDateTime(),
+        hits,
+        imageDtos,
+        detail
+    );
   }
 }

--- a/src/main/java/kr/megaptera/smash/models/Role.java
+++ b/src/main/java/kr/megaptera/smash/models/Role.java
@@ -5,10 +5,6 @@ import kr.megaptera.smash.dtos.RoleDto;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import java.util.List;
 
 @Entity
 public class Role {
@@ -16,35 +12,48 @@ public class Role {
   @GeneratedValue
   private Long id;
 
-  @ManyToOne
-  @JoinColumn(name = "TEAM_ID")
-  private Team teamIn;
+  private Long teamId;
 
   private String name;
 
   private Integer targetParticipantsCount;
 
-  @OneToMany(mappedBy = "roleIn")
-  private List<Member> participantsUnder;
-
   public Role() {
 
   }
 
-  public Role(Long id, Team teamIn, String name, Integer targetParticipantsCount, List<Member> participantsUnder) {
+  public Role(Long id,
+              Long teamId,
+              String name,
+              Integer targetParticipantsCount) {
     this.id = id;
-    this.teamIn = teamIn;
+    this.teamId = teamId;
     this.name = name;
     this.targetParticipantsCount = targetParticipantsCount;
-    this.participantsUnder = participantsUnder;
   }
 
-  public RoleDto toRoleDto() {
+  public Long id() {
+    return id;
+  }
+
+  public Long teamId() {
+    return teamId;
+  }
+
+  public String name() {
+    return name;
+  }
+
+  public Integer targetParticipantsCount() {
+    return targetParticipantsCount;
+  }
+
+  public RoleDto toDto(Integer participantsCount) {
     return new RoleDto(
         id,
-        teamIn.id(),
+        teamId,
         name,
-        participantsUnder.size(),
+        participantsCount,
         targetParticipantsCount
     );
   }

--- a/src/main/java/kr/megaptera/smash/models/Team.java
+++ b/src/main/java/kr/megaptera/smash/models/Team.java
@@ -5,10 +5,6 @@ import kr.megaptera.smash.dtos.TeamDto;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import java.util.List;
 
 @Entity
 public class Team {
@@ -16,46 +12,103 @@ public class Team {
   @GeneratedValue
   private Long id;
 
-  @ManyToOne
-  @JoinColumn(name = "POST_ID")
-  private Post postIn;
+  private Long postId;
 
   private String name;
 
+  private String exercise;
+
+  private String exerciseDate;
+
+  private String exerciseType;
+
+  private String exerciseLevel;
+
+  private String exerciseGender;
+
   private Integer targetMembersCount;
 
-  @OneToMany(mappedBy = "teamIn")
-  private List<Member> membersUnder;
-
-  @OneToMany(mappedBy = "teamIn")
-  private List<Role> rolesUnder;
+  private Integer cost;
 
   public Team() {
 
   }
 
-  public Team(Long id, Post postIn, List<Member> membersUnder, Integer targetMembersCount) {
+  public Team(Long id,
+              Long postId,
+              String name,
+              String exercise,
+              String exerciseDate,
+              String exerciseType,
+              String exerciseLevel,
+              String exerciseGender,
+              Integer targetMembersCount,
+              Integer cost) {
     this.id = id;
-    this.postIn = postIn;
-    this.membersUnder = membersUnder;
+    this.postId = postId;
+    this.name = name;
+    this.exercise = exercise;
+    this.exerciseDate = exerciseDate;
+    this.exerciseType = exerciseType;
+    this.exerciseLevel = exerciseLevel;
+    this.exerciseGender = exerciseGender;
     this.targetMembersCount = targetMembersCount;
-  }
-
-  public Team(Long id) {
-    this.id = id;
-  }
-
-  public TeamDto toTeamDto() {
-    return new TeamDto(
-        id,
-        postIn.id(),
-        name,
-        membersUnder.size(),
-        targetMembersCount
-    );
+    this.cost = cost;
   }
 
   public Long id() {
     return id;
+  }
+
+  public Long postId() {
+    return postId;
+  }
+
+  public String name() {
+    return name;
+  }
+
+  public String exercise() {
+    return exercise;
+  }
+
+  public String exerciseDate() {
+    return exerciseDate;
+  }
+
+  public String exerciseType() {
+    return exerciseType;
+  }
+
+  public String exerciseLevel() {
+    return exerciseLevel;
+  }
+
+  public String exerciseGender() {
+    return exerciseGender;
+  }
+
+  public Integer targetMembersCount() {
+    return targetMembersCount;
+  }
+
+  public Integer cost() {
+    return cost;
+  }
+
+  public TeamDto toDto(Integer membersCount) {
+    return new TeamDto(
+        id,
+        postId,
+        name,
+        exercise,
+        exerciseDate,
+        exerciseType,
+        exerciseLevel,
+        exerciseGender,
+        membersCount,
+        targetMembersCount,
+        cost
+    );
   }
 }

--- a/src/main/java/kr/megaptera/smash/models/User.java
+++ b/src/main/java/kr/megaptera/smash/models/User.java
@@ -3,25 +3,18 @@ package kr.megaptera.smash.models;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
-import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
 import javax.persistence.Table;
-import java.util.List;
 
 @Entity
 @Table(name = "PERSON")
 public class User {
   @Id
   @GeneratedValue
-  private Long personId;
+  private Long id;
 
   private String name;
 
-  @OneToMany(mappedBy = "author")
-  private List<Post> createdPosts;
-
-  @OneToOne(mappedBy = "person")
-  private Member member;
+  private Double mannerScore;
 
   public User() {
 
@@ -31,7 +24,17 @@ public class User {
     this.name = name;
   }
 
-  public String author() {
+  public User(Long id, String name, Double mannerScore) {
+    this.id = id;
+    this.name = name;
+    this.mannerScore = mannerScore;
+  }
+
+  public String name() {
     return name;
+  }
+
+  public Double mannerScore() {
+    return mannerScore;
   }
 }

--- a/src/main/java/kr/megaptera/smash/repositories/ImageRepository.java
+++ b/src/main/java/kr/megaptera/smash/repositories/ImageRepository.java
@@ -1,0 +1,10 @@
+package kr.megaptera.smash.repositories;
+
+import kr.megaptera.smash.models.Image;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+  List<Image> findAllByPostId(Long postId);
+}

--- a/src/main/java/kr/megaptera/smash/repositories/MemberRepository.java
+++ b/src/main/java/kr/megaptera/smash/repositories/MemberRepository.java
@@ -3,6 +3,9 @@ package kr.megaptera.smash.repositories;
 import kr.megaptera.smash.models.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+import java.util.List;
 
+public interface MemberRepository extends JpaRepository<Member, Long> {
+   List<Member> findAllByTeamId(Long teamId);
+   List<Member> findAllByRoleId(Long roleId);
 }

--- a/src/main/java/kr/megaptera/smash/repositories/PlaceRepository.java
+++ b/src/main/java/kr/megaptera/smash/repositories/PlaceRepository.java
@@ -1,0 +1,8 @@
+package kr.megaptera.smash.repositories;
+
+import kr.megaptera.smash.models.Place;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlaceRepository extends JpaRepository<Place, Long> {
+  Place findByPostId(Long postId);
+}

--- a/src/main/java/kr/megaptera/smash/services/ImageService.java
+++ b/src/main/java/kr/megaptera/smash/services/ImageService.java
@@ -1,0 +1,22 @@
+package kr.megaptera.smash.services;
+
+import kr.megaptera.smash.models.Image;
+import kr.megaptera.smash.repositories.ImageRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class ImageService {
+  private final ImageRepository imageRepository;
+
+  public ImageService(ImageRepository imageRepository) {
+    this.imageRepository = imageRepository;
+  }
+
+  public List<Image> imagesByPost(Long postId) {
+    return imageRepository.findAllByPostId(postId);
+  }
+}

--- a/src/main/java/kr/megaptera/smash/services/MemberService.java
+++ b/src/main/java/kr/megaptera/smash/services/MemberService.java
@@ -1,0 +1,34 @@
+package kr.megaptera.smash.services;
+
+import kr.megaptera.smash.models.Member;
+import kr.megaptera.smash.repositories.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class MemberService {
+  private final MemberRepository memberRepository;
+
+  public MemberService(MemberRepository memberRepository) {
+    this.memberRepository = memberRepository;
+  }
+
+  public List<Member> members() {
+    return memberRepository.findAll();
+  }
+
+  public Integer membersCountByTeam(Long teamId) {
+    List<Member> membersWithTeam = memberRepository.findAllByTeamId(teamId);
+
+    return membersWithTeam.size();
+  }
+
+  public Integer membersCountByRole(Long roleId) {
+    List<Member> membersWithRole = memberRepository.findAllByRoleId(roleId);
+
+    return membersWithRole.size();
+  }
+}

--- a/src/main/java/kr/megaptera/smash/services/PlaceService.java
+++ b/src/main/java/kr/megaptera/smash/services/PlaceService.java
@@ -1,0 +1,28 @@
+package kr.megaptera.smash.services;
+
+import kr.megaptera.smash.models.Place;
+import kr.megaptera.smash.models.Post;
+import kr.megaptera.smash.repositories.PlaceRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class PlaceService {
+  private final PlaceRepository placeRepository;
+
+  public PlaceService(PlaceRepository placeRepository) {
+    this.placeRepository = placeRepository;
+  }
+
+  public List<Place> placesInPosts(List<Post> posts) {
+    return posts.stream()
+        .map(post -> {
+          System.out.println(post.id());
+          return placeRepository.findByPostId(post.id());
+        })
+        .toList();
+  }
+}

--- a/src/main/java/kr/megaptera/smash/services/PostService.java
+++ b/src/main/java/kr/megaptera/smash/services/PostService.java
@@ -1,15 +1,7 @@
 package kr.megaptera.smash.services;
 
-import kr.megaptera.smash.dtos.PostThumbnailDto;
-import kr.megaptera.smash.dtos.PostThumbnailsDto;
-import kr.megaptera.smash.dtos.RoleDto;
-import kr.megaptera.smash.dtos.TeamDto;
 import kr.megaptera.smash.models.Post;
-import kr.megaptera.smash.models.Role;
-import kr.megaptera.smash.models.Team;
 import kr.megaptera.smash.repositories.PostRepository;
-import kr.megaptera.smash.repositories.RoleRepository;
-import kr.megaptera.smash.repositories.TeamRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,32 +11,12 @@ import java.util.List;
 @Transactional
 public class PostService {
   private final PostRepository postRepository;
-  private final TeamRepository teamRepository;
-  private final RoleRepository roleRepository;
 
-  public PostService(PostRepository postRepository,
-                     TeamRepository teamRepository,
-                     RoleRepository roleRepository) {
+  public PostService(PostRepository postRepository) {
     this.postRepository = postRepository;
-    this.teamRepository = teamRepository;
-    this.roleRepository = roleRepository;
   }
 
-  public PostThumbnailsDto posts() {
-    List<Post> posts = postRepository.findAll();
-    List<Team> teams = teamRepository.findAll();
-    List<Role> roles = roleRepository.findAll();
-
-    List<PostThumbnailDto> postThumbnailDto = posts.stream()
-        .map(Post::toThumbnailDto)
-        .toList();
-    List<TeamDto> teamDto = teams.stream()
-        .map(Team::toTeamDto)
-        .toList();
-    List<RoleDto> roleDto = roles.stream()
-        .map(Role::toRoleDto)
-        .toList();
-
-    return new PostThumbnailsDto(postThumbnailDto, teamDto, roleDto);
+  public List<Post> posts() {
+    return postRepository.findAll();
   }
 }

--- a/src/main/java/kr/megaptera/smash/services/RoleService.java
+++ b/src/main/java/kr/megaptera/smash/services/RoleService.java
@@ -1,0 +1,16 @@
+package kr.megaptera.smash.services;
+
+import kr.megaptera.smash.models.Role;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class RoleService {
+
+  public List<Role> roles() {
+    return null;
+  }
+}

--- a/src/main/java/kr/megaptera/smash/services/TeamService.java
+++ b/src/main/java/kr/megaptera/smash/services/TeamService.java
@@ -1,0 +1,22 @@
+package kr.megaptera.smash.services;
+
+import kr.megaptera.smash.models.Team;
+import kr.megaptera.smash.repositories.TeamRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class TeamService {
+  private final TeamRepository teamRepository;
+
+  public TeamService(TeamRepository teamRepository) {
+    this.teamRepository = teamRepository;
+  }
+
+  public List<Team> teams() {
+    return teamRepository.findAll();
+  }
+}

--- a/src/main/java/kr/megaptera/smash/services/UserService.java
+++ b/src/main/java/kr/megaptera/smash/services/UserService.java
@@ -1,0 +1,21 @@
+package kr.megaptera.smash.services;
+
+import kr.megaptera.smash.exceptions.UserNotFound;
+import kr.megaptera.smash.models.User;
+import kr.megaptera.smash.repositories.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class UserService {
+  private final UserRepository userRepository;
+
+  public UserService(UserRepository userRepository) {
+    this.userRepository = userRepository;
+  }
+
+  public User user(Long id) {
+    return userRepository.findById(id).orElseThrow(UserNotFound::new);
+  }
+}

--- a/src/test/java/kr/megaptera/smash/controllers/PostControllerTest.java
+++ b/src/test/java/kr/megaptera/smash/controllers/PostControllerTest.java
@@ -1,10 +1,19 @@
 package kr.megaptera.smash.controllers;
 
-import kr.megaptera.smash.dtos.PostThumbnailDto;
-import kr.megaptera.smash.dtos.PostThumbnailsDto;
-import kr.megaptera.smash.dtos.RoleDto;
-import kr.megaptera.smash.dtos.TeamDto;
+import kr.megaptera.smash.models.Image;
+import kr.megaptera.smash.models.Member;
+import kr.megaptera.smash.models.Place;
+import kr.megaptera.smash.models.Post;
+import kr.megaptera.smash.models.Role;
+import kr.megaptera.smash.models.Team;
+import kr.megaptera.smash.models.User;
+import kr.megaptera.smash.services.ImageService;
+import kr.megaptera.smash.services.MemberService;
+import kr.megaptera.smash.services.PlaceService;
 import kr.megaptera.smash.services.PostService;
+import kr.megaptera.smash.services.RoleService;
+import kr.megaptera.smash.services.TeamService;
+import kr.megaptera.smash.services.UserService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -26,33 +35,103 @@ class PostControllerTest {
   @MockBean
   private PostService postService;
 
+  @MockBean
+  private TeamService teamService;
+
+  @MockBean
+  private RoleService roleService;
+
+  @MockBean
+  private MemberService memberService;
+
+  @MockBean
+  private PlaceService placeService;
+
+  @MockBean
+  private ImageService imageService;
+
+  @MockBean
+  private UserService userService;
+
   @Test
   void posts() throws Exception {
-    PostThumbnailsDto postThumbnailsDto = new PostThumbnailsDto(
-        List.of(
-            // id, author, detail
-            new PostThumbnailDto(1L, "작성자 1", "Local Baseball Family"),
-            new PostThumbnailDto(3L, "작성자 2", "Soccer Gogo")
-        ),
-        List.of(
-            // id, postId, name, membersCount, targetMembersCount
-            new TeamDto(1L, 1L, "단일 팀", 4, 12),
-            new TeamDto(2L, 3L, "단일 팀", 5, 6)
-        ),
-        List.of(
-            // id, teamId, name, currentParticipants, targetParticipantsCount
-            new RoleDto(1L, 1L, "투수", 0, 3),
-            new RoleDto(2L, 1L, "내야수", 2, 5),
-            new RoleDto(3L, 1L, "외야수", 2, 4),
-            new RoleDto(4L, 2L, "자유포지션", 5, 6)
-        )
+    List<User> users = List.of(
+        new User(1L, "User 1", 7.5),
+        new User(2L, "User 2", 5.0),
+        new User(3L, "User 3", 8.0),
+        new User(4L, "User 4", 9.0),
+        new User(5L, "User 5", 5.0),
+        new User(6L, "Author 1", 10.0),
+        new User(7L, "Author 2", 7.7)
     );
-    given(postService.posts()).willReturn(postThumbnailsDto);
+
+    List<Post> posts = List.of(
+        // id, userId
+        new Post(1L, 1L, "Gathering", 15, "Play baseball with me"),
+        new Post(2L, 2L, "Gathering", 30, "Play football with me")
+    );
+    given(postService.posts()).willReturn(posts);
+    given(userService.user(1L)).willReturn(users.get(5));
+    given(imageService.imagesByPost(1L)).willReturn((
+        List.of(
+            new Image(1L, 1L, "Main Baseball Image Url", true),
+            new Image(2L, 1L, "Sub Baseball Image Url", false)
+        )));
+    given(userService.user(2L)).willReturn(users.get(6));
+    given(imageService.imagesByPost(2L)).willReturn((
+        List.of(
+            new Image(3L, 2L, "Main Soccer Image Url", true)
+        )));
+
+    List<Team> teams = List.of(
+        // id, postId
+        new Team(1L, 1L, "Team 1",
+            "Baseball", "11월 1일 18:00 ~ 21:00",
+            "Practice", "Amateur", "Male",
+            12, 10000),
+        new Team(2L, 2L, "Team 1",
+            "Soccer", "11월 2일 15:00 ~ 17:00",
+            "Actual Game", "Professional", "mixed",
+            6, 5000)
+    );
+    given(teamService.teams()).willReturn(teams);
+    given(memberService.membersCountByTeam(1L)).willReturn(4);
+    given(memberService.membersCountByTeam(2L)).willReturn(1);
+
+    List<Role> roles = List.of(
+        // id, teamId
+        new Role(1L, 1L, "Pitcher", 3),
+        new Role(2L, 1L, "Infielder", 5),
+        new Role(3L, 1L, "Outfielder", 4),
+        new Role(4L, 2L, "Free", 6));
+    given(roleService.roles()).willReturn(roles);
+    given(memberService.membersCountByRole(1L)).willReturn(0);
+    given(memberService.membersCountByRole(2L)).willReturn(2);
+    given(memberService.membersCountByRole(3L)).willReturn(2);
+    given(memberService.membersCountByRole(4L)).willReturn(1);
+
+    List<Member> members = List.of(
+        // id, teamId, roleId, userId
+        new Member(1L, 1L, 2L, 1L),
+        new Member(2L, 1L, 2L, 2L),
+        new Member(3L, 1L, 3L, 3L),
+        new Member(4L, 1L, 3L, 4L),
+        new Member(5L, 2L, 4L, 5L)
+    );
+    given(memberService.members()).willReturn(members);
+    given(userService.user(1L)).willReturn(users.get(0));
+    given(userService.user(2L)).willReturn(users.get(1));
+    given(userService.user(3L)).willReturn(users.get(2));
+    given(userService.user(4L)).willReturn(users.get(3));
+    given(userService.user(5L)).willReturn(users.get(4));
+
+    List<Place> places = List.of(
+        // id, teamId
+        new Place(1L, 1L, "Guui Baseball Park"),
+        new Place(2L, 2L, "Jayang Middle School"));
+    given(placeService.placesInPosts(posts)).willReturn(places);
 
     mockMvc.perform(MockMvcRequestBuilders.get("/posts/list"))
-        .andExpect(MockMvcResultMatchers.status().isOk())
-        .andExpect(MockMvcResultMatchers.content().string(
-            containsString("Local Baseball Family")
-        ));
+        .andExpect(MockMvcResultMatchers.status().isOk());
   }
 }

--- a/src/test/java/kr/megaptera/smash/services/ImageServiceTest.java
+++ b/src/test/java/kr/megaptera/smash/services/ImageServiceTest.java
@@ -1,0 +1,43 @@
+package kr.megaptera.smash.services;
+
+import kr.megaptera.smash.models.Image;
+import kr.megaptera.smash.repositories.ImageRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class ImageServiceTest {
+  private ImageService imageService;
+  private ImageRepository imageRepository;
+
+  @BeforeEach
+  void setUp() {
+    imageRepository = mock(ImageRepository.class);
+    imageService = new ImageService(imageRepository);
+  }
+
+  @Test
+  void imagesByPost() {
+    Long postId = 1L;
+    List<Image> images = List.of(
+        new Image(1L, 1L, "Main Cycling Image Url", true),
+        new Image(2L, 1L, "Sub Cycling Image Url", false)
+    );
+    given(imageRepository.findAllByPostId(postId))
+        .willReturn(images);
+
+    List<Image> foundImages = imageService.imagesByPost(postId);
+
+    assertThat(foundImages).hasSize(2);
+    assertThat(foundImages.get(1).url()).contains("Image Url");
+
+    verify(imageRepository).findAllByPostId(any(Long.class));
+  }
+}

--- a/src/test/java/kr/megaptera/smash/services/MemberServiceTest.java
+++ b/src/test/java/kr/megaptera/smash/services/MemberServiceTest.java
@@ -1,0 +1,88 @@
+package kr.megaptera.smash.services;
+
+import kr.megaptera.smash.models.Member;
+import kr.megaptera.smash.repositories.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class MemberServiceTest {
+  private MemberService memberService;
+  private MemberRepository memberRepository;
+
+  @BeforeEach
+  void setUp() {
+    memberRepository = mock(MemberRepository.class);
+    memberService = new MemberService(memberRepository);
+  }
+
+  @Test
+  void members() {
+    List<Member> members = List.of(
+        new Member(1L, 1L, 2L, 1L),
+        new Member(2L, 1L, 2L, 2L),
+        new Member(3L, 1L, 3L, 3L),
+        new Member(4L, 1L, 3L, 4L),
+        new Member(5L, 2L, 4L, 5L)
+    );
+
+    given(memberRepository.findAll()).willReturn(members);
+
+    List<Member> foundMembers = memberService.members();
+
+    assertThat(foundMembers).isNotNull();
+    assertThat(foundMembers).hasSize(5);
+
+    verify(memberRepository).findAll();
+  }
+
+  @Test
+  void membersCountByTeam() {
+    List<Member> membersWithTeam = List.of(
+        new Member(1L, 1L, 2L, 1L),
+        new Member(2L, 1L, 2L, 2L),
+        new Member(3L, 1L, 3L, 3L),
+        new Member(4L, 1L, 3L, 4L)
+    );
+    Long teamId = 1L;
+    given(memberRepository.findAllByTeamId(teamId)).willReturn(membersWithTeam);
+
+    Integer count = memberService.membersCountByTeam(teamId);
+
+    assertThat(count).isEqualTo(4);
+
+    verify(memberRepository).findAllByTeamId(any(Long.class));
+  }
+
+  @Test
+  void membersCountByRole() {
+    List<Member> membersWithRoleId1L = List.of();
+    Long roleId1 = 1L;
+
+    given(memberRepository.findAllByRoleId(roleId1))
+        .willReturn(membersWithRoleId1L);
+    Integer count1 = memberService.membersCountByRole(roleId1);
+    assertThat(count1).isEqualTo(0);
+
+    verify(memberRepository).findAllByRoleId(1L);
+
+    List<Member> membersWithRoleId2L = List.of(
+        new Member(1L, 1L, 2L, 1L),
+        new Member(2L, 1L, 2L, 2L)
+    );
+    Long roleId2 = 2L;
+    given(memberRepository.findAllByRoleId(roleId2))
+        .willReturn(membersWithRoleId2L);
+    Integer count2 = memberService.membersCountByRole(roleId2);
+    assertThat(count2).isEqualTo(2);
+
+    verify(memberRepository).findAllByRoleId(2L);
+  }
+}

--- a/src/test/java/kr/megaptera/smash/services/PlaceServiceTest.java
+++ b/src/test/java/kr/megaptera/smash/services/PlaceServiceTest.java
@@ -1,0 +1,47 @@
+package kr.megaptera.smash.services;
+
+import kr.megaptera.smash.models.Place;
+import kr.megaptera.smash.models.Post;
+import kr.megaptera.smash.repositories.PlaceRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class PlaceServiceTest {
+  private PlaceService placeService;
+  private PlaceRepository placeRepository;
+
+  @BeforeEach
+  void setUp() {
+    placeRepository = mock(PlaceRepository.class);
+    placeService = new PlaceService(placeRepository);
+  }
+
+  @Test
+  void placesInPosts() {
+    List<Post> posts = List.of(
+        new Post(1L, 1L, "Gathering", 15, "Play baseball with me"),
+        new Post(2L, 2L, "Gathering", 30, "Play football with me")
+    );
+    List<Place> places = List.of(
+        new Place(1L, 1L, "Guui Baseball Park"),
+        new Place(2L, 2L, "Jayang Middle School"));
+
+    given(placeRepository.findByPostId(1L)).willReturn(places.get(0));
+    given(placeRepository.findByPostId(2L)).willReturn(places.get(1));
+
+    List<Place> placesInPosts = placeService.placesInPosts(posts);
+
+    assertThat(placesInPosts).isNotNull();
+    assertThat(placesInPosts.get(0).name()).contains("Baseball Park");
+
+    verify(placeRepository).findByPostId(1L);
+    verify(placeRepository).findByPostId(2L);
+  }
+}

--- a/src/test/java/kr/megaptera/smash/services/PostServiceTest.java
+++ b/src/test/java/kr/megaptera/smash/services/PostServiceTest.java
@@ -1,19 +1,13 @@
 package kr.megaptera.smash.services;
 
-import kr.megaptera.smash.dtos.PostThumbnailsDto;
-import kr.megaptera.smash.models.Member;
 import kr.megaptera.smash.models.Post;
-import kr.megaptera.smash.models.Role;
-import kr.megaptera.smash.models.Team;
-import kr.megaptera.smash.models.User;
 import kr.megaptera.smash.repositories.PostRepository;
-import kr.megaptera.smash.repositories.RoleRepository;
-import kr.megaptera.smash.repositories.TeamRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -21,82 +15,26 @@ import static org.mockito.Mockito.verify;
 class PostServiceTest {
   private PostService postService;
   private PostRepository postRepository;
-  private TeamRepository teamRepository;
-  private RoleRepository roleRepository;
 
   @BeforeEach
   void setUp() {
     postRepository = mock(PostRepository.class);
-    teamRepository = mock(TeamRepository.class);
-    roleRepository = mock(RoleRepository.class);
-    postService = new PostService(
-        postRepository,
-        teamRepository,
-        roleRepository
-    );
+    postService = new PostService(postRepository);
   }
 
   @Test
   void posts() {
-    given(postRepository.findAll())
-        .willReturn(List.of(
-            // id, author, detail
-            new Post(1L, new User("작성자 1"), "동네 야구대회 나가실 분 모집합니다"),
-            new Post(3L, new User("작성자 2"), "풋살마렵네 재야의 고수들 모여라")
-        ));
-    given(teamRepository.findAll())
-        .willReturn(List.of(
-            // id, postIn, name, membersUnder, targetMembersCount
-            new Team(
-                1L,
-                new Post(1L),
-                List.of(new Member(), new Member(), new Member(), new Member()),
-                12
-            ),
-            new Team(
-                2L,
-                new Post(3L),
-                List.of(new Member(), new Member(), new Member(), new Member(), new Member()),
-                6
-            )
-        ));
-    given(roleRepository.findAll())
-        .willReturn(List.of(
-            // id, teamIn, name, targetParticipantsCount
-            new Role(
-                1L,
-                new Team(1L),
-                "투수",
-                3,
-                List.of()
-            ),
-            new Role(
-                2L,
-                new Team(1L),
-                "내야수",
-                5,
-                List.of(new Member(), new Member())
-            ),
-            new Role(
-                3L,
-                new Team(1L),
-                "외야수",
-                4,
-                List.of(new Member(), new Member())
-            ),
-            new Role(
-                4L,
-                new Team(2L),
-                "자유포지션",
-                6,
-                List.of(new Member(), new Member(), new Member(), new Member(), new Member())
-            )
-        ));
+    List<Post> posts = List.of(
+        // id, userId
+        new Post(1L, 1L, "Gathering", 15, "Play baseball with me"),
+        new Post(2L, 2L, "Gathering", 30, "Play football with me")
+    );
+    given(postRepository.findAll()).willReturn(posts);
 
-    PostThumbnailsDto postThumbnailsDto = postService.posts();
+    List<Post> foundPosts = postService.posts();
+
+    assertThat(foundPosts).isNotNull();
 
     verify(postRepository).findAll();
-    verify(teamRepository).findAll();
-    verify(roleRepository).findAll();
   }
 }

--- a/src/test/java/kr/megaptera/smash/services/TeamServiceTest.java
+++ b/src/test/java/kr/megaptera/smash/services/TeamServiceTest.java
@@ -1,0 +1,68 @@
+package kr.megaptera.smash.services;
+
+import kr.megaptera.smash.models.Team;
+import kr.megaptera.smash.repositories.TeamRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class TeamServiceTest {
+  private TeamService teamService;
+  private TeamRepository teamRepository;
+
+  @BeforeEach
+  void setUp() {
+    teamRepository = mock(TeamRepository.class);
+    teamService = new TeamService(teamRepository);
+  }
+
+  @Test
+  void teams() {
+    List<Team> teams = List.of(
+        new Team(1L, 1L, "Team 1",
+            "Baseball", "11월 1일 18:00 ~ 21:00",
+            "Practice", "Amateur", "Male",
+            12, 10000),
+        new Team(2L, 2L, "Team 1",
+            "Soccer", "11월 2일 15:00 ~ 17:00",
+            "Actual Game", "Professional", "mixed",
+            6, 5000)
+    );
+    given(teamRepository.findAll()).willReturn(teams);
+
+    List<Team> foundTeams = teamService.teams();
+
+    assertThat(foundTeams).isNotNull();
+    assertThat(foundTeams).hasSize(2);
+
+    verify(teamRepository).findAll();
+  }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/test/java/kr/megaptera/smash/services/UserServiceTest.java
+++ b/src/test/java/kr/megaptera/smash/services/UserServiceTest.java
@@ -1,0 +1,57 @@
+package kr.megaptera.smash.services;
+
+import kr.megaptera.smash.models.User;
+import kr.megaptera.smash.repositories.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class UserServiceTest {
+  private UserService userService;
+  private UserRepository userRepository;
+
+  @BeforeEach
+  void setUp() {
+    userRepository = mock(UserRepository.class);
+    userService = new UserService(userRepository);
+  }
+
+  @Test
+  void author() {
+    Long postId = 1L;
+    User user = new User(6L, "Author 1", 10.0);
+
+    given(userRepository.findById(postId))
+        .willReturn(Optional.of(user));
+
+    User author = userService.user(postId);
+
+    assertThat(author).isNotNull();
+    assertThat(author.name()).isEqualTo("Author 1");
+
+    verify(userRepository).findById(any(Long.class));
+  }
+
+  @Test
+  void participant() {
+    Long userId = 2L;
+    User user = new User(1L, "Participant 1", 1.0);
+
+    given(userRepository.findById(userId))
+        .willReturn(Optional.of(user));
+
+    User author = userService.user(userId);
+
+    assertThat(author).isNotNull();
+    assertThat(author.mannerScore()).isEqualTo(1.0);
+
+    verify(userRepository).findById(any(Long.class));
+  }
+}


### PR DESCRIPTION
모델에 https://github.com/users/hsjkdss228/projects/3/views/1 에서 했던
모델 정의를 바탕으로 모델에 데이터를 추가하는데,
@OneToMany나 @ManyToOne이 단방향으로 연결되어 있는 부분을 양방향으로 다시 연결해야 함
테스트 수행, 데이터 생성 시 객체를 직접 만들어서 추가하는 경우가 있을 수 있는데, 그때 해당 객체를 직접 생성할 수 있어야 하기 때문
(연결될 객체 필드가 없으면 객체를 직접 생성해야 할 때 자신이 연결된 객체를 알려줄 방법이 없음)
양방향으로 연결하면서 무한 루프에 빠지는지 확인해보기

컨트롤러에서 확장한 형태의 DTO를 테스트 코드를 작성하면서 먼저 구성 (서비스에서 꺼내오는 것까지는 보되, 절대값을 부여)
컨트롤러가 지금은 서비스에서 DTO까지 만들어서 바로 받아오도록 하고 있는데, 각각의 Repository의 서비스로부터 가져와서 합치도록 해야되나?

그 후 서비스에서 Repository로부터 데이터를 받아오는 테스트 코드 작성

11/1 19:25 시작

11/3 07:30 완료
예상 뽀모: 4
실제 뽀모: 11

왜 이렇게까지 차이가 많이 났나?
- 중간에 모델 구조를 OneToMany, ManyToOne에서 이들을 사용하지 않는 구조로 변경했음
- 사실 오히려 OneToMany 시리즈를 사용했으면 더 오래 걸렸을 수도 있을 것 같음, 양방향 구조를 갖는 인스턴스 둘을 동시에 설정해줘야 하는 테스트 코드를 짜기가 어려웠음
- 리스트가 갖는 덩어리 자체가 매우 컸음, DTO를 합치는 구조는 잘 작성했는데 커버해야 하는 범위가 많았던 것 같음