### PR TITLE
게시글 상세정보 조회 요청 시 클라이언트의 유저 정보를 확인해 유저의 신청 상태 전달

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'com.auth0:java-jwt:4.2.1'
 
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 

--- a/src/main/java/kr/megaptera/smash/SmashApplication.java
+++ b/src/main/java/kr/megaptera/smash/SmashApplication.java
@@ -1,14 +1,22 @@
 package kr.megaptera.smash;
 
+import kr.megaptera.smash.interceptors.AuthenticationInterceptor;
+import kr.megaptera.smash.utils.JwtUtil;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @SpringBootApplication
 public class SmashApplication {
+  @Value("${jwt.secret}")
+  private String jwtSecret;
+
   public static void main(String[] args) {
     SpringApplication.run(SmashApplication.class, args);
   }
@@ -22,9 +30,24 @@ public class SmashApplication {
   public WebMvcConfigurer corsConfigurer() {
     return new WebMvcConfigurer() {
       @Override
+      public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authenticationInterceptor());
+      }
+
+      @Override
       public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**").allowedOrigins("*");
       }
     };
+  }
+
+  @Bean
+  public HandlerInterceptor authenticationInterceptor() {
+    return new AuthenticationInterceptor(jwtUtil());
+  }
+
+  @Bean
+  public JwtUtil jwtUtil() {
+    return new JwtUtil(jwtSecret);
   }
 }

--- a/src/main/java/kr/megaptera/smash/advices/AuthenticationErrorAdvice.java
+++ b/src/main/java/kr/megaptera/smash/advices/AuthenticationErrorAdvice.java
@@ -1,0 +1,18 @@
+package kr.megaptera.smash.advices;
+
+import kr.megaptera.smash.exceptions.AuthenticationError;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ControllerAdvice
+public class AuthenticationErrorAdvice {
+  @ResponseBody
+  @ExceptionHandler(AuthenticationError.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public String authenticationError(AuthenticationError exception) {
+    return exception.getMessage();
+  }
+}

--- a/src/main/java/kr/megaptera/smash/controllers/PostController.java
+++ b/src/main/java/kr/megaptera/smash/controllers/PostController.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -27,9 +28,10 @@ public class PostController {
 
   @GetMapping("/posts/{postId}")
   public PostDto post(
-      @PathVariable Long postId
+      @PathVariable Long postId,
+      @RequestAttribute("userId") Long accessedUserId
   ) {
-    return postService.post(postId);
+    return postService.post(postId, accessedUserId);
   }
 
   @ExceptionHandler(PostNotFound.class)

--- a/src/main/java/kr/megaptera/smash/dtos/GameDto.java
+++ b/src/main/java/kr/megaptera/smash/dtos/GameDto.java
@@ -23,6 +23,10 @@ public class GameDto {
 
   private final List<TeamDto> teams;
 
+  private final String userStatus;
+
+  private final Long roleIdOfAccessedUser;
+
   public GameDto(Long id,
                  Long postId,
                  String exercise,
@@ -44,6 +48,35 @@ public class GameDto {
     this.cost = cost;
     this.place = place;
     this.teams = teams;
+    this.userStatus = null;
+    this.roleIdOfAccessedUser = null;
+  }
+
+  public GameDto(Long id,
+                 Long postId,
+                 String exercise,
+                 String exerciseDate,
+                 String exerciseType,
+                 String exerciseLevel,
+                 String exerciseGender,
+                 Integer cost,
+                 String place,
+                 List<TeamDto> teams,
+                 String userStatus,
+                 Long roleIdOfAccessedUser
+  ) {
+    this.id = id;
+    this.postId = postId;
+    this.exercise = exercise;
+    this.exerciseDate = exerciseDate;
+    this.exerciseType = exerciseType;
+    this.exerciseLevel = exerciseLevel;
+    this.exerciseGender = exerciseGender;
+    this.cost = cost;
+    this.place = place;
+    this.teams = teams;
+    this.userStatus = userStatus;
+    this.roleIdOfAccessedUser = roleIdOfAccessedUser;
   }
 
   public Long getId() {
@@ -84,5 +117,13 @@ public class GameDto {
 
   public List<TeamDto> getTeams() {
     return teams;
+  }
+
+  public String getUserStatus() {
+    return userStatus;
+  }
+
+  public Long getRoleIdOfAccessedUser() {
+    return roleIdOfAccessedUser;
   }
 }

--- a/src/main/java/kr/megaptera/smash/exceptions/AuthenticationError.java
+++ b/src/main/java/kr/megaptera/smash/exceptions/AuthenticationError.java
@@ -1,0 +1,7 @@
+package kr.megaptera.smash.exceptions;
+
+public class AuthenticationError extends RuntimeException {
+  public AuthenticationError() {
+    super("인가 과정에서 문제가 발생했습니다.");
+  }
+}

--- a/src/main/java/kr/megaptera/smash/interceptors/AuthenticationInterceptor.java
+++ b/src/main/java/kr/megaptera/smash/interceptors/AuthenticationInterceptor.java
@@ -1,0 +1,38 @@
+package kr.megaptera.smash.interceptors;
+
+import com.auth0.jwt.exceptions.JWTDecodeException;
+import kr.megaptera.smash.exceptions.AuthenticationError;
+import kr.megaptera.smash.utils.JwtUtil;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class AuthenticationInterceptor implements HandlerInterceptor {
+  private final JwtUtil jwtUtil;
+
+  public AuthenticationInterceptor(JwtUtil jwtUtil) {
+    this.jwtUtil = jwtUtil;
+  }
+
+  @Override
+  public boolean preHandle(HttpServletRequest request,
+                           HttpServletResponse response,
+                           Object handler) throws Exception {
+    String authorization = request.getHeader("Authorization");
+
+    if (authorization == null || !authorization.startsWith("Bearer ")) {
+      return true;
+    }
+
+    String accessToken = authorization.substring("Bearer ".length());
+
+    try {
+      Long userId = jwtUtil.decode(accessToken);
+      request.setAttribute("userId", userId);
+      return true;
+    } catch (JWTDecodeException exception) {
+      throw new AuthenticationError();
+    }
+  }
+}

--- a/src/main/java/kr/megaptera/smash/models/Game.java
+++ b/src/main/java/kr/megaptera/smash/models/Game.java
@@ -55,7 +55,10 @@ public class Game {
     return id;
   }
 
-  public GameDto toDto(String place, List<TeamDto> teams) {
+  public GameDto toDto(
+      String place,
+      List<TeamDto> teams
+  ) {
     return new GameDto(
         id,
         postId,
@@ -67,6 +70,28 @@ public class Game {
         cost,
         place,
         teams
+    );
+  }
+
+  public GameDto toDto(
+      String place,
+      List<TeamDto> teams,
+      String userStatus,
+      Long roleIdOfAccessedUser
+  ) {
+    return new GameDto(
+        id,
+        postId,
+        exercise,
+        exerciseDate,
+        exerciseType,
+        exerciseLevel,
+        exerciseGender,
+        cost,
+        place,
+        teams,
+        userStatus,
+        roleIdOfAccessedUser
     );
   }
 }

--- a/src/main/java/kr/megaptera/smash/models/Post.java
+++ b/src/main/java/kr/megaptera/smash/models/Post.java
@@ -52,7 +52,7 @@ public class Post {
     return id;
   }
 
-  public Long userId() {
+  public Long authorId() {
     return authorId;
   }
 

--- a/src/main/java/kr/megaptera/smash/utils/JwtUtil.java
+++ b/src/main/java/kr/megaptera/smash/utils/JwtUtil.java
@@ -1,0 +1,27 @@
+package kr.megaptera.smash.utils;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+
+public class JwtUtil {
+  private final Algorithm algorithm;
+
+  public JwtUtil(String secret) {
+    this.algorithm = Algorithm.HMAC256(secret);
+  }
+
+  public String encode(Long userId) {
+    return JWT.create()
+        .withClaim("userId", userId)
+        .sign(algorithm);
+  }
+
+  public Long decode(String token) {
+    JWTVerifier verifier = JWT.require(algorithm)
+        .build();
+    DecodedJWT verified = verifier.verify(token);
+    return verified.getClaim("userId").asLong();
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,6 +6,8 @@ spring.datasource.password=
 
 spring.jpa.hibernate.ddl-auto=update
 
+jwt.secret=JWTSECRET
+
 #---
 spring.config.activate.on-profile=test
 spring.datasource.url=jdbc:h2:mem:test

--- a/src/test/java/kr/megaptera/smash/controllers/PostControllerTest.java
+++ b/src/test/java/kr/megaptera/smash/controllers/PostControllerTest.java
@@ -1,10 +1,13 @@
 package kr.megaptera.smash.controllers;
 
 import kr.megaptera.smash.services.PostService;
+import kr.megaptera.smash.utils.JwtUtil;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -19,6 +22,17 @@ class PostControllerTest {
   @MockBean
   private PostService postService;
 
+  @SpyBean
+  private JwtUtil jwtUtil;
+
+  private String token;
+
+  @BeforeEach
+  void setUp() {
+    Long userId = 1L;
+    token  = jwtUtil.encode(userId);
+  }
+
   @Test
   void posts() throws Exception {
     mockMvc.perform(MockMvcRequestBuilders.get("/posts/list"))
@@ -27,7 +41,8 @@ class PostControllerTest {
 
   @Test
   void post() throws Exception {
-    mockMvc.perform(MockMvcRequestBuilders.get("/posts/1"))
+    mockMvc.perform(MockMvcRequestBuilders.get("/posts/1")
+        .header("Authorization", "Bearer " + token))
         .andExpect(MockMvcResultMatchers.status().isOk());
   }
 }

--- a/src/test/java/kr/megaptera/smash/utils/JwtUtilTest.java
+++ b/src/test/java/kr/megaptera/smash/utils/JwtUtilTest.java
@@ -1,0 +1,28 @@
+package kr.megaptera.smash.utils;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JwtUtilTest {
+  private static final String SECRET = "JWTSECRET";
+
+  private JwtUtil jwtUtil;
+
+  @BeforeEach
+  void setUp() {
+    jwtUtil = new JwtUtil(SECRET);
+  }
+
+  @Test
+  void encodeAndDecode() {
+    Long userId = 1L;
+
+    String accessToken = jwtUtil.encode(userId);
+    assertThat(accessToken).contains(".");
+
+    Long original = jwtUtil.decode(accessToken);
+    assertThat(original).isEqualTo(userId);
+  }
+}


### PR DESCRIPTION
1. 클라이언트로부터 전달받은 토큰을 인터셉터에서 디코딩한다.
2. memberRepository에서 gameId로 모든 Member List를 찾는다.
3. Member 중에 해독한 userId와 같은 userId를 갖는 멤버가 있다? 그러면 GameDto에 userStatus에는 "registered"를 넣고, 그 Member가 갖고 있는 RoleId 값을 또 넣는다. 없으면 userStatus에 "not-registered"를 넣고, RoleId 값으로는 0을 넣는다. (0이면 해독한 userId의 유저는 그 글에 신청을 안 했다는 얘기)
4. 해독한 userId가 post의 authorId와 같은지 확인한다. 같으면 웹으로 접속하고 있는 사용자는 글 작성자인 것임. 같으면 GameDto에 userStatus라는 변수로 "author"를 넣고, RoleId 값으로는 0을 넣는다. (작성자는 완전히 다른 컴포넌트를 표출하도록 할 것이기 때문에 RoleId를 사용하지 않는다.)

예상 뽀모: 6
실제 뽀모: 13
(프론트엔드, 백엔드를 둘 다 합친 시간)

어떤 점으로 인해 오래 걸렸나?
createPostDto를 게시글 목록 조회와 게시글 상세 내용 조회에서 동시에 사용하고 있어서 다른 기능의 메서드에도 영향을 끼치는 문제점이 있었음, createPostDto를 오버로딩으로 접근하도록 해 문제를 해결했으나 많은 중복이 발생하고 있음