### PR TITLE
운동 게시글 목록 조회 시 AccessToken 기준 버튼 컴포넌트 출력 구분

### DIFF
--- a/src/main/java/kr/megaptera/smash/controllers/BackdoorController.java
+++ b/src/main/java/kr/megaptera/smash/controllers/BackdoorController.java
@@ -49,27 +49,27 @@ public class BackdoorController {
         );
         jdbcTemplate.update(
             "insert into MEMBER(" +
-                "ID, GAME_ID, NAME) " +
-                "values(?, ?, ?)",
-            1L, 1L, "운동 1 참가자 1"
+                "ID, USER_ID, GAME_ID, NAME) " +
+                "values(?, ?, ?, ?)",
+            1L, 1L, 1L, "운동 1 참가자 1"
         );
         jdbcTemplate.update(
             "insert into MEMBER(" +
-                "ID, GAME_ID, NAME) " +
-                "values(?, ?, ?)",
-            2L, 1L, "운동 1 참가자 2"
+                "ID, USER_ID, GAME_ID, NAME) " +
+                "values(?, ?, ?, ?)",
+            2L, 2L, 1L, "운동 1 참가자 2"
         );
         jdbcTemplate.update(
             "insert into MEMBER(" +
-                "ID, GAME_ID, NAME) " +
-                "values(?, ?, ?)",
-            3L, 1L, "운동 1 참가자 3"
+                "ID, USER_ID, GAME_ID, NAME) " +
+                "values(?, ?, ?, ?)",
+            3L, 3L, 1L, "운동 1 참가자 3"
         );
         jdbcTemplate.update(
             "insert into MEMBER(" +
-                "ID, GAME_ID, NAME) " +
-                "values(?, ?, ?)",
-            4L, 2L, "운동 2 참가자 1"
+                "ID, USER_ID, GAME_ID, NAME) " +
+                "values(?, ?, ?, ?)",
+            4L, 4L, 2L, "운동 2 참가자 1"
         );
 
         return "게시물 목록 조회 백도어 세팅이 완료되었습니다.";

--- a/src/main/java/kr/megaptera/smash/controllers/PostController.java
+++ b/src/main/java/kr/megaptera/smash/controllers/PostController.java
@@ -7,6 +7,7 @@ import kr.megaptera.smash.services.GetPostsService;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,8 +20,10 @@ public class PostController {
     }
 
     @GetMapping("/posts")
-    public PostsDto posts() {
-        return getPostsService.findAll();
+    public PostsDto posts(
+        @RequestAttribute("userId") Long accessedUserId
+    ) {
+        return getPostsService.findAll(accessedUserId);
     }
 
     @ExceptionHandler(PostNotFound.class)

--- a/src/main/java/kr/megaptera/smash/dtos/GameInPostListDto.java
+++ b/src/main/java/kr/megaptera/smash/dtos/GameInPostListDto.java
@@ -11,17 +11,20 @@ public class GameInPostListDto {
 
     private final Integer targetMemberCount;
 
+    private final Boolean isRegistered;
+
     public GameInPostListDto(String type,
                              String date,
                              String place,
                              Integer currentMemberCount,
-                             Integer targetMemberCount
-    ) {
+                             Integer targetMemberCount,
+                             Boolean isRegistered) {
         this.type = type;
         this.date = date;
         this.place = place;
         this.currentMemberCount = currentMemberCount;
         this.targetMemberCount = targetMemberCount;
+        this.isRegistered = isRegistered;
     }
 
     public String getType() {
@@ -42,5 +45,9 @@ public class GameInPostListDto {
 
     public Integer getTargetMemberCount() {
         return targetMemberCount;
+    }
+
+    public Boolean getIsRegistered() {
+        return isRegistered;
     }
 }

--- a/src/main/java/kr/megaptera/smash/models/Game.java
+++ b/src/main/java/kr/megaptera/smash/models/Game.java
@@ -78,13 +78,15 @@ public class Game {
     );
   }
 
-  public GameInPostListDto toGameInPostListDto(Integer currentMemberCount) {
+  public GameInPostListDto toGameInPostListDto(Integer currentMemberCount,
+                                               Boolean isRegistered) {
     return new GameInPostListDto(
         type,
         date,
         place,
         currentMemberCount,
-        targetMemberCount
+        targetMemberCount,
+        isRegistered
     );
   }
 }

--- a/src/main/java/kr/megaptera/smash/models/Member.java
+++ b/src/main/java/kr/megaptera/smash/models/Member.java
@@ -10,6 +10,8 @@ public class Member {
   @GeneratedValue
   private Long id;
 
+  private Long userId;
+
   private Long gameId;
 
   private String name;
@@ -18,20 +20,31 @@ public class Member {
 
   }
 
-  public Member(Long id, Long gameId, String name) {
+  public Member(Long id,
+                Long userId,
+                Long gameId,
+                String name) {
     this.id = id;
+    this.userId = userId;
     this.gameId = gameId;
     this.name = name;
   }
 
   // TODO: 알아볼 수 없는 값들을 값 객체로 정의
 
-  public static Member fake(Long id, Long gameId) {
+  public static Member fake(Long id,
+                            Long userId,
+                            Long gameId) {
     return new Member(
       id,
+      userId,
       gameId,
       "참가자 이름"
     );
+  }
+
+  public Long userId() {
+    return userId;
   }
 
   public Long gameId() {

--- a/src/main/java/kr/megaptera/smash/models/Person.java
+++ b/src/main/java/kr/megaptera/smash/models/Person.java
@@ -3,16 +3,16 @@ package kr.megaptera.smash.models;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
-import javax.persistence.Table;
 
 @Entity
-@Table(name = "PERSON")
 public class Person {
   @Id
   @GeneratedValue
   private Long id;
 
-  // TODO: 성별이 추가되어야 함
+  private String name;
+
+  private String gender;
 
   private Person() {
 

--- a/src/main/java/kr/megaptera/smash/services/GetPostsService.java
+++ b/src/main/java/kr/megaptera/smash/services/GetPostsService.java
@@ -31,7 +31,7 @@ public class GetPostsService {
         this.memberRepository = memberRepository;
     }
 
-    public PostsDto findAll() {
+    public PostsDto findAll(Long accessedUserId) {
         List<Post> posts = postRepository.findAll();
 
         List<Game> games = posts.stream()
@@ -45,12 +45,14 @@ public class GetPostsService {
             members.addAll(membersOfGame);
         });
 
-        return createPostDtos(posts, games, members);
+        return createPostDtos(posts, games, members, accessedUserId);
     }
 
     private PostsDto createPostDtos(List<Post> posts,
                                     List<Game> games,
-                                    List<Member> members) {
+                                    List<Member> members,
+                                    Long accessedUserId
+    ) {
         List<PostListDto> postListDtos = posts.stream()
             .map(post -> {
                 Game gameOfPost = games.stream()
@@ -62,8 +64,13 @@ public class GetPostsService {
                     .toList()
                     .size();
 
+                Boolean isRegistered = members.stream()
+                    .anyMatch(member -> member.gameId().equals(gameOfPost.id())
+                            && member.userId().equals(accessedUserId));
+
                 GameInPostListDto gameInPostListDto
-                    = gameOfPost.toGameInPostListDto(currentMemberCount);
+                    = gameOfPost.toGameInPostListDto(
+                        currentMemberCount, isRegistered);
 
                 return post.toPostListDto(gameInPostListDto);
             })

--- a/src/test/java/kr/megaptera/smash/services/GetPostsServiceTest.java
+++ b/src/test/java/kr/megaptera/smash/services/GetPostsServiceTest.java
@@ -46,11 +46,11 @@ class GetPostsServiceTest {
         Game gameOfPost1 = Game.fake(1L, 1L);
         Game gameOfPost2 = Game.fake(2L, 2L);
         List<Member> membersOfGame1 = List.of(
-            Member.fake(1L, 1L),
-            Member.fake(2L, 1L)
+            Member.fake(1L, 1L, 1L),
+            Member.fake(2L, 2L, 1L)
         );
         List<Member> membersOfGame2 = List.of(
-            Member.fake(3L, 2L)
+            Member.fake(3L, 3L, 2L)
         );
 
         given(postRepository.findAll()).willReturn(posts);
@@ -59,7 +59,8 @@ class GetPostsServiceTest {
         given(memberRepository.findByGameId(1L)).willReturn(membersOfGame1);
         given(memberRepository.findByGameId(2L)).willReturn(membersOfGame2);
 
-        PostsDto postsDto = getPostsService.findAll();
+        Long accessedUserId = 1L;
+        PostsDto postsDto = getPostsService.findAll(accessedUserId);
 
         assertThat(postsDto).isNotNull();
 
@@ -67,8 +68,10 @@ class GetPostsServiceTest {
         assertThat(postListDtos.get(0).getId()).isEqualTo(1L);
         assertThat(postListDtos.get(0).getGame().getType()).isEqualTo("운동 종류");
         assertThat(postListDtos.get(0).getGame().getCurrentMemberCount()).isEqualTo(2);
+        assertThat(postListDtos.get(0).getGame().getIsRegistered()).isEqualTo(true);
         assertThat(postListDtos.get(1).getHits()).isEqualTo(100L);
         assertThat(postListDtos.get(1).getGame().getPlace()).isEqualTo("운동 장소");
         assertThat(postListDtos.get(1).getGame().getCurrentMemberCount()).isEqualTo(1);
+        assertThat(postListDtos.get(1).getGame().getIsRegistered()).isEqualTo(false);
     }
 }


### PR DESCRIPTION
사용자가 특정 운동에 참가를 신청하지 않았으면 신청 버튼이,
참가를 신청했으면 신청취소 버튼 출력
  
백엔드
1. decode에는 기존에 정의했던 Interceptor 활용
2. Member 모델에 userId 요소 추가
3. Member 모델이 가진 userId와 헤더로 전달된 userId를 비교 검사 후 Dto에 유저 판별 값을 추가

예상 뽀모: 3
사용 뽀모: 2

회고
Service에서 멤버 리스트를 한번에 전부 가져오고 있어서 각 게시물마다 멤버를
어떻게 판별해줄지 고민했는데, 멤버가 gameId를 갖고 있으므로
게시물의 게임 id와 멤버의 gameId를 비교해 각 게시물의 멤버만을 분류할 수 있었음