### PR TITLE
fake 메서드 인터페이스 수정

### DIFF
--- a/src/main/java/kr/megaptera/smash/models/Game.java
+++ b/src/main/java/kr/megaptera/smash/models/Game.java
@@ -7,92 +7,99 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "games")
 public class Game {
-  @Id
-  @GeneratedValue
-  private Long id;
+    @Id
+    @GeneratedValue
+    private Long id;
 
-  private Long postId;
+    private Long postId;
 
-  @Embedded
-  private Exercise exercise;
+    @Embedded
+    private Exercise exercise;
 
-  @Embedded
-  private GameDate date;
+    @Embedded
+    private GameDate date;
 
-  @Embedded
-  private Place place;
+    @Embedded
+    private Place place;
 
-  @Embedded
-  private GameTargetMemberCount targetMemberCount;
+    @Embedded
+    private GameTargetMemberCount targetMemberCount;
 
-  private Game() {
+    private Game() {
 
-  }
+    }
 
-  public Game(Long id,
-              Long postId,
-              Exercise exercise,
-              GameDate date,
-              Place place,
-              GameTargetMemberCount targetMemberCount
-  ) {
-    this.id = id;
-    this.postId = postId;
-    this.exercise = exercise;
-    this.date = date;
-    this.place = place;
-    this.targetMemberCount = targetMemberCount;
-  }
+    public Game(Long id,
+                Long postId,
+                Exercise exercise,
+                GameDate date,
+                Place place,
+                GameTargetMemberCount targetMemberCount
+    ) {
+        this.id = id;
+        this.postId = postId;
+        this.exercise = exercise;
+        this.date = date;
+        this.place = place;
+        this.targetMemberCount = targetMemberCount;
+    }
 
-  public Long id() {
-    return id;
-  }
+    public Long id() {
+        return id;
+    }
 
-  public Long postId() {
-    return postId;
-  }
+    public Long postId() {
+        return postId;
+    }
 
-  public Exercise exercise() {
-    return exercise;
-  }
+    public Exercise exercise() {
+        return exercise;
+    }
 
-  public GameDate date() {
-    return date;
-  }
+    public GameDate date() {
+        return date;
+    }
 
-  public Place place() {
-    return place;
-  }
+    public Place place() {
+        return place;
+    }
 
-  public GameTargetMemberCount targetMemberCount() {
-    return targetMemberCount;
-  }
+    public GameTargetMemberCount targetMemberCount() {
+        return targetMemberCount;
+    }
 
-  public static Game fake(Long id, Long postId) {
-    return new Game(
-        id,
-        postId,
-        new Exercise("운동 종류"),
-        new GameDate("운동 날짜"),
-        new Place("운동 장소"),
-        new GameTargetMemberCount(5)
-    );
-  }
+    public static List<Game> fakes(long generationCount) {
+        List<Game> games = new ArrayList<>();
+        for (long id = 1; id <= generationCount; id += 1) {
+            Game game = new Game(
+                id,
+                id,
+                new Exercise("운동 종류"),
+                new GameDate("운동 날짜"),
+                new Place("운동 장소"),
+                new GameTargetMemberCount(10)
+            );
+            games.add(game);
+        }
+        return games;
+    }
 
-  public GameInPostListDto toGameInPostListDto(Integer currentMemberCount,
-                                               Boolean isRegistered) {
-    return new GameInPostListDto(
-        id,
-        exercise.name(),
-        date.value(),
-        place.name(),
-        currentMemberCount,
-        targetMemberCount.value(),
-        isRegistered
-    );
-  }
+    public GameInPostListDto toGameInPostListDto(Integer currentMemberCount,
+                                                 Boolean isRegistered) {
+        return new GameInPostListDto(
+            id,
+            exercise.name(),
+            date.value(),
+            place.name(),
+            currentMemberCount,
+            targetMemberCount.value(),
+            isRegistered
+        );
+    }
 }

--- a/src/main/java/kr/megaptera/smash/models/Member.java
+++ b/src/main/java/kr/megaptera/smash/models/Member.java
@@ -1,80 +1,70 @@
 package kr.megaptera.smash.models;
 
-import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "members")
 public class Member {
-  @Id
-  @GeneratedValue
-  private Long id;
+    @Id
+    @GeneratedValue
+    private Long id;
 
-  private Long userId;
+    private Long userId;
 
-  private Long gameId;
+    private Long gameId;
 
-  @Embedded
-  private MemberName name;
+    @Embedded
+    private MemberName name;
 
-  private Member() {
+    private Member() {
 
-  }
+    }
 
-  public Member(Long id,
-                Long userId,
-                Long gameId,
-                MemberName name
-  ) {
-    this.id = id;
-    this.userId = userId;
-    this.gameId = gameId;
-    this.name = name;
-  }
+    public Member(Long id,
+                  Long userId,
+                  Long gameId,
+                  MemberName name
+    ) {
+        this.id = id;
+        this.userId = userId;
+        this.gameId = gameId;
+        this.name = name;
+    }
 
-  public Member(Long userId,
-                Long gameId,
-                MemberName name
-  ) {
-    this.userId = userId;
-    this.gameId = gameId;
-    this.name = name;
-  }
+    public Member(Long userId,
+                  Long gameId,
+                  MemberName name
+    ) {
+        this.userId = userId;
+        this.gameId = gameId;
+        this.name = name;
+    }
 
-  public Long userId() {
-    return userId;
-  }
+    public Long userId() {
+        return userId;
+    }
 
-  public Long gameId() {
-    return gameId;
-  }
+    public Long gameId() {
+        return gameId;
+    }
 
-  public static Member fake(Long id,
-                            Long userId,
-                            Long gameId
-  ) {
-    return new Member(
-      id,
-      userId,
-      gameId,
-      new MemberName("참가자 이름")
-    );
-  }
-
-  public static Member fake(Long id,
-                            Long userId,
-                            Long gameId,
-                            MemberName name
-  ) {
-    return new Member(
-        id,
-        userId,
-        gameId,
-        name
-    );
-  }
+    public static List<Member> fakes(long generationCount, long gameId) {
+        List<Member> members = new ArrayList<>();
+        for (long id = 1; id <= generationCount; id += 1) {
+            Member member = new Member(
+                id,
+                id,
+                gameId,
+                new MemberName("참가자명")
+            );
+            members.add(member);
+        }
+        return members;
+    }
 }

--- a/src/main/java/kr/megaptera/smash/models/Post.java
+++ b/src/main/java/kr/megaptera/smash/models/Post.java
@@ -11,69 +11,78 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+// TODO: id를 값 객체로 정의하는 경우 GeneratedValue 어노테이션을 사용할 수 없음,
+//   다른 모델이 해당 모델의 id를 갖고 있는 경우 때문에 그런 것 같음
+//   생성자로 생성될 때만 id 생성기를 사용해서 id를 부여해야 할 것 같은데...
 
 @Entity
 @Table(name = "posts")
 public class Post {
-  @Id
-  @GeneratedValue
-  private Long id;
+    @Id
+    @GeneratedValue
+    private Long id;
 
-  @Embedded
-  private PostHits hits;
+    @Embedded
+    private PostHits hits;
 
-  @CreationTimestamp
-  private LocalDateTime createdAt;
+    @CreationTimestamp
+    private LocalDateTime createdAt;
 
-  @UpdateTimestamp
-  private LocalDateTime updatedAt;
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
 
-  private Post() {
+    private Post() {
 
-  }
+    }
 
-  public Post(Long id,
-              PostHits hits
-  ) {
-    this.id = id;
-    this.hits = hits;
-  }
+    public Post(Long id,
+                PostHits hits
+    ) {
+        this.id = id;
+        this.hits = hits;
+    }
 
-  public Post(Long id,
-              PostHits hits,
-              LocalDateTime createdAt,
-              LocalDateTime updatedAt
-  ) {
-    this.id = id;
-    this.hits = hits;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
-  }
+    public Post(Long id,
+                PostHits hits,
+                LocalDateTime createdAt,
+                LocalDateTime updatedAt
+    ) {
+        this.id = id;
+        this.hits = hits;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
 
-  public Long id() {
-    return id;
-  }
+    public Long id() {
+        return id;
+    }
 
-  public PostHits hits() {
-    return hits;
-  }
+    public PostHits hits() {
+        return hits;
+    }
 
-  // TODO: 알아볼 수 없는 값들을 값 객체로 정의
+    public static List<Post> fakes(long generationCount) {
+        List<Post> posts = new ArrayList<>();
+        for (long id = 1; id <= generationCount; id += 1) {
+            Post post = new Post(
+                id,
+                new PostHits(123L),
+                LocalDateTime.now(),
+                LocalDateTime.now()
+            );
+            posts.add(post);
+        }
+        return posts;
+    }
 
-  public static Post fake(Long id) {
-    return new Post(
-        id,
-        new PostHits(100L),
-        LocalDateTime.now(),
-        LocalDateTime.now()
-    );
-  }
-
-  public PostListDto toPostListDto(GameInPostListDto gameInPostListDto) {
-    return new PostListDto(
-        id,
-        hits.value(),
-        gameInPostListDto
-    );
-  }
+    public PostListDto toPostListDto(GameInPostListDto gameInPostListDto) {
+        return new PostListDto(
+            id,
+            hits.value(),
+            gameInPostListDto
+        );
+    }
 }

--- a/src/main/java/kr/megaptera/smash/models/User.java
+++ b/src/main/java/kr/megaptera/smash/models/User.java
@@ -35,12 +35,4 @@ public class User {
     public UserName name() {
         return name;
     }
-
-    public static User fake(Long id) {
-        return new User(
-            id,
-            new UserName("유저 이름"),
-            new UserGender("성별")
-        );
-    }
 }

--- a/src/test/java/kr/megaptera/smash/controllers/PostControllerTest.java
+++ b/src/test/java/kr/megaptera/smash/controllers/PostControllerTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.hamcrest.Matchers.containsString;
@@ -44,44 +45,41 @@ class PostControllerTest {
     void setUp() {
         token = jwtUtil.encode(userId);
 
-        Post post1 = Post.fake(1L);
-        Game gameOfPost1 = Game.fake(1L, 1L);
-        List<Member> membersOfGame1 = List.of(
-            Member.fake(1L, 1L, 1L),
-            Member.fake(2L, 2L, 1L)
-        );
-        Post post2 = Post.fake(2L);
-        Game gameOfPost2 = Game.fake(2L, 2L);
-        List<Member> membersOfGame2 = List.of(
-            Member.fake(3L, 3L, 2L)
-        );
+        long generationCount = 2;
+        List<Post> posts = Post.fakes(generationCount);
+        List<Game> games = Game.fakes(generationCount);
+        List<List<Member>> membersOfGames = new ArrayList<>();
+        for (long gameId = 1; gameId <= generationCount; gameId += 1) {
+            List<Member> members = Member.fakes(generationCount, gameId);
+            membersOfGames.add(members);
+        }
 
         // TODO: true, false를 어떻게 의미있는 값으로 반환?
 
         postListDtos = List.of(
             new PostListDto(
-                post1.id(),
-                post1.hits().value(),
+                posts.get(0).id(),
+                posts.get(0).hits().value(),
                 new GameInPostListDto(
-                    gameOfPost1.id(),
-                    gameOfPost1.exercise().name(),
-                    gameOfPost1.date().value(),
-                    gameOfPost1.place().name(),
-                    membersOfGame1.size(),
-                    gameOfPost1.targetMemberCount().value(),
+                    games.get(0).id(),
+                    games.get(0).exercise().name(),
+                    games.get(0).date().value(),
+                    games.get(0).place().name(),
+                    membersOfGames.get(0).size(),
+                    games.get(0).targetMemberCount().value(),
                     true
                 )
             ),
             new PostListDto(
-                post2.id(),
-                post2.hits().value(),
+                posts.get(1).id(),
+                posts.get(1).hits().value(),
                 new GameInPostListDto(
-                    gameOfPost2.id(),
-                    gameOfPost2.exercise().name(),
-                    gameOfPost2.date().value(),
-                    gameOfPost2.place().name(),
-                    membersOfGame2.size(),
-                    gameOfPost2.targetMemberCount().value(),
+                    games.get(1).id(),
+                    games.get(1).exercise().name(),
+                    games.get(1).date().value(),
+                    games.get(1).place().name(),
+                    membersOfGames.get(1).size(),
+                    games.get(1).targetMemberCount().value(),
                     false
                 )
             )
@@ -97,13 +95,13 @@ class PostControllerTest {
                 .header("Authorization", "Bearer " + token))
             .andExpect(MockMvcResultMatchers.status().isOk())
             .andExpect(MockMvcResultMatchers.content().string(
-                containsString("\"hits\":100")
+                containsString("\"hits\":123")
             ))
             .andExpect(MockMvcResultMatchers.content().string(
                 containsString("\"game\":{\"id\":1")
             ))
             .andExpect(MockMvcResultMatchers.content().string(
-                containsString("\"currentMemberCount\":1")
+                containsString("\"currentMemberCount\":2")
             ))
             .andExpect(MockMvcResultMatchers.content().string(
                 containsString("\"isRegistered\":false")

--- a/src/test/java/kr/megaptera/smash/services/GetPostsServiceTest.java
+++ b/src/test/java/kr/megaptera/smash/services/GetPostsServiceTest.java
@@ -11,6 +11,7 @@ import kr.megaptera.smash.repositories.PostRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -39,25 +40,20 @@ class GetPostsServiceTest {
 
     @Test
     void posts() {
-        List<Post> posts = List.of(
-            Post.fake(1L),
-            Post.fake(2L)
-        );
-        Game gameOfPost1 = Game.fake(1L, 1L);
-        Game gameOfPost2 = Game.fake(2L, 2L);
-        List<Member> membersOfGame1 = List.of(
-            Member.fake(1L, 1L, 1L),
-            Member.fake(2L, 2L, 1L)
-        );
-        List<Member> membersOfGame2 = List.of(
-            Member.fake(3L, 3L, 2L)
-        );
+        long generationCount = 2;
+        List<Post> posts = Post.fakes(generationCount);
+        List<Game> games = Game.fakes(generationCount);
+        List<List<Member>> membersOfGames = new ArrayList<>();
+        for (long gameId = 1; gameId <= generationCount; gameId += 1) {
+            List<Member> members = Member.fakes(generationCount, gameId);
+            membersOfGames.add(members);
+        }
 
         given(postRepository.findAll()).willReturn(posts);
-        given(gameRepository.findByPostId(1L)).willReturn(Optional.of(gameOfPost1));
-        given(gameRepository.findByPostId(2L)).willReturn(Optional.of(gameOfPost2));
-        given(memberRepository.findByGameId(1L)).willReturn(membersOfGame1);
-        given(memberRepository.findByGameId(2L)).willReturn(membersOfGame2);
+        given(gameRepository.findByPostId(1L)).willReturn(Optional.of(games.get(0)));
+        given(gameRepository.findByPostId(2L)).willReturn(Optional.of(games.get(1)));
+        given(memberRepository.findByGameId(1L)).willReturn(membersOfGames.get(0));
+        given(memberRepository.findByGameId(2L)).willReturn(membersOfGames.get(1));
 
         Long accessedUserId = 1L;
         PostsDto postsDto = getPostsService.findAll(accessedUserId);
@@ -69,9 +65,9 @@ class GetPostsServiceTest {
         assertThat(postListDtos.get(0).getGame().getType()).isEqualTo("운동 종류");
         assertThat(postListDtos.get(0).getGame().getCurrentMemberCount()).isEqualTo(2);
         assertThat(postListDtos.get(0).getGame().getIsRegistered()).isEqualTo(true);
-        assertThat(postListDtos.get(1).getHits()).isEqualTo(100L);
+        assertThat(postListDtos.get(1).getHits()).isEqualTo(123L);
         assertThat(postListDtos.get(1).getGame().getPlace()).isEqualTo("운동 장소");
-        assertThat(postListDtos.get(1).getGame().getCurrentMemberCount()).isEqualTo(1);
-        assertThat(postListDtos.get(1).getGame().getIsRegistered()).isEqualTo(false);
+        assertThat(postListDtos.get(1).getGame().getCurrentMemberCount()).isEqualTo(2);
+        assertThat(postListDtos.get(1).getGame().getIsRegistered()).isEqualTo(true);
     }
 }

--- a/src/test/java/kr/megaptera/smash/services/PostRegisterGameServiceTest.java
+++ b/src/test/java/kr/megaptera/smash/services/PostRegisterGameServiceTest.java
@@ -1,10 +1,16 @@
 package kr.megaptera.smash.services;
 
 import kr.megaptera.smash.dtos.RegisterGameResultDto;
+import kr.megaptera.smash.models.Exercise;
 import kr.megaptera.smash.models.Game;
+import kr.megaptera.smash.models.GameDate;
+import kr.megaptera.smash.models.GameTargetMemberCount;
 import kr.megaptera.smash.models.Member;
 import kr.megaptera.smash.models.MemberName;
+import kr.megaptera.smash.models.Place;
 import kr.megaptera.smash.models.User;
+import kr.megaptera.smash.models.UserGender;
+import kr.megaptera.smash.models.UserName;
 import kr.megaptera.smash.repositories.GameRepository;
 import kr.megaptera.smash.repositories.MemberRepository;
 import kr.megaptera.smash.repositories.UserRepository;
@@ -42,23 +48,28 @@ class PostRegisterGameServiceTest {
 
     @Test
     void registerGame() {
-        Long userId = 1L;
         Long gameId = 1L;
-        Game game = Game.fake(1L, 1L);
+        Game game = new Game(
+            gameId,
+            1L,
+            new Exercise("운동 종류"),
+            new GameDate("운동 날짜"),
+            new Place("운동 장소"),
+            new GameTargetMemberCount(5)
+        );
         given(gameRepository.findById(gameId)).willReturn(Optional.of(game));
 
         List<Member> members = List.of(
-            // TODO: 신청 작업 백엔드 마무리되면 즉시 사용되는 객체들을 값 객체로 변환!!!!
-            // id, userId, gameId
-            Member.fake(1L, 2L, gameId),
-            Member.fake(2L, 3L, gameId)
+            new Member(1L, 2L, gameId, new MemberName("참가자 1")),
+            new Member(2L, 3L, gameId, new MemberName("참가자 2"))
         );
         given(memberRepository.findByGameId(gameId)).willReturn(members);
 
-        User user = User.fake(userId);
+        Long userId = 1L;
+        User user = new User(userId, new UserName("사용자명"), new UserGender("남성"));
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
-        Member registeredMember = Member.fake(3L, userId, gameId, new MemberName(user.name().value()));
+        Member registeredMember = new Member(3L, userId, gameId, new MemberName(user.name().value()));
         given(memberRepository.save(any(Member.class))).willReturn(registeredMember);
 
         RegisterGameResultDto registerGameResultDto


### PR DESCRIPTION
테스트 코드 가독성 개선을 위한 fake 메서드 개선
  
fakes 메서드를 정의해 게시글 리스트 테스트 데이터 생성에 사용
  
fake 메서드는 Controller 테스트에서만 사용하고,
Service Test에서는 생성자를 직접 쓰는 방식으로 변경
  
시작하기 전 4뽀모 소요 (아샬님과의 질의응답)

예상 뽀모 6
실제 뽀모 7

회고
fake 메서드에 인자를 2개 이상 주지 않는 방향으로 구현하려 했는데,
Members 같은 경우에는 fake 메서드에 2개의 인자를 주고 있고,
(생성할 개별 인스턴수 개수, 연결되어야 할 gameId)
반복문을 이용해 테스트용 인스턴스를 생성하고 있기 때문에
깔끔하게 뺐다기보다는 다소 지저분하게 느껴지는 부분이 있어 걱정