### PR TITLE
게시글 리스트 조회 에러 핸들러 생성

### DIFF
--- a/src/main/java/kr/megaptera/smash/controllers/PostController.java
+++ b/src/main/java/kr/megaptera/smash/controllers/PostController.java
@@ -1,8 +1,8 @@
 package kr.megaptera.smash.controllers;
 
-import kr.megaptera.smash.dtos.PostNotFoundErrorDto;
 import kr.megaptera.smash.dtos.PostsDto;
-import kr.megaptera.smash.exceptions.PostNotFound;
+import kr.megaptera.smash.dtos.PostsFailedErrorDto;
+import kr.megaptera.smash.exceptions.PostsFailed;
 import kr.megaptera.smash.services.GetPostsService;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -26,9 +26,9 @@ public class PostController {
         return getPostsService.findAll(accessedUserId);
     }
 
-    @ExceptionHandler(PostNotFound.class)
+    @ExceptionHandler(PostsFailed.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public PostNotFoundErrorDto postNotFound(PostNotFound exception) {
-        return new PostNotFoundErrorDto(exception.getMessage());
+    public PostsFailedErrorDto postsFailed(PostsFailed exception) {
+        return new PostsFailedErrorDto(exception.getMessage());
     }
 }

--- a/src/main/java/kr/megaptera/smash/dtos/PostsFailedErrorDto.java
+++ b/src/main/java/kr/megaptera/smash/dtos/PostsFailedErrorDto.java
@@ -1,0 +1,13 @@
+package kr.megaptera.smash.dtos;
+
+public class PostsFailedErrorDto {
+    private final String errorMessage;
+
+    public PostsFailedErrorDto(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+}

--- a/src/main/java/kr/megaptera/smash/exceptions/PostsFailed.java
+++ b/src/main/java/kr/megaptera/smash/exceptions/PostsFailed.java
@@ -1,0 +1,7 @@
+package kr.megaptera.smash.exceptions;
+
+public class PostsFailed extends RuntimeException {
+    public PostsFailed(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/kr/megaptera/smash/controllers/PostControllerTest.java
+++ b/src/test/java/kr/megaptera/smash/controllers/PostControllerTest.java
@@ -3,6 +3,7 @@ package kr.megaptera.smash.controllers;
 import kr.megaptera.smash.dtos.GameInPostListDto;
 import kr.megaptera.smash.dtos.PostListDto;
 import kr.megaptera.smash.dtos.PostsDto;
+import kr.megaptera.smash.exceptions.PostsFailed;
 import kr.megaptera.smash.models.Game;
 import kr.megaptera.smash.models.Member;
 import kr.megaptera.smash.models.Post;
@@ -32,10 +33,10 @@ class PostControllerTest {
     @MockBean
     private GetPostsService getPostsService;
 
-    private List<PostListDto> postListDtos;
-
     @SpyBean
     private JwtUtil jwtUtil;
+
+    private List<PostListDto> postListDtos;
 
     private Long userId = 1L;
 
@@ -105,6 +106,20 @@ class PostControllerTest {
             ))
             .andExpect(MockMvcResultMatchers.content().string(
                 containsString("\"isRegistered\":false")
+            ))
+        ;
+    }
+
+    @Test
+    void postsFailed() throws Exception {
+        given(getPostsService.findAll(userId))
+            .willThrow(PostsFailed.class);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/posts")
+                .header("Authorization", "Bearer " + token))
+            .andExpect(MockMvcResultMatchers.status().isBadRequest())
+            .andExpect(MockMvcResultMatchers.content().string(
+                containsString("errorMessage")
             ))
         ;
     }


### PR DESCRIPTION
백엔드
- 에러 발생 시 에러 DTO를 반환
- 발생하는 에러: PostsFailed
  - 특정 게시물에 게임이 없는 경우 반환되는 에러

프론트엔드
- Store에서 에러 DTO로 반환되는 상태를 저장 후
  게시물 목록과 별도로 전달
- Guard Clause 형태로 출력시키기

예상 뽀모: 2
실제 뽀모: 1

회고
- 여러 게시물들 중 특정 게시물 하나에만 게임이 없다고 해서
  PostsDto 대신 PostsFailedErrorDto를 반환하는 게 맞는지는 고민이 있다.
