### PR TITLE
운동 신청 관련 에러 핸들러 추가

### DIFF
--- a/src/main/java/kr/megaptera/smash/controllers/RegisterController.java
+++ b/src/main/java/kr/megaptera/smash/controllers/RegisterController.java
@@ -1,8 +1,11 @@
 package kr.megaptera.smash.controllers;
 
+import kr.megaptera.smash.dtos.RegisterGameFailedErrorDto;
 import kr.megaptera.smash.dtos.RegisterGameResultDto;
+import kr.megaptera.smash.exceptions.RegisterGameFailed;
 import kr.megaptera.smash.services.PostRegisterGameService;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
@@ -13,6 +16,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("registers")
 public class RegisterController {
+    private static final Integer GAME_NOT_FOUND = 100;
+    private static final Integer ALREADY_REGISTERED_GAME = 101;
+    private static final Integer USER_NOT_FOUND = 102;
+    private static final Integer DEFAULT = 103;
+
     private final PostRegisterGameService postRegisterGameService;
 
     public RegisterController(PostRegisterGameService postRegisterGameService) {
@@ -27,4 +35,24 @@ public class RegisterController {
     ) {
         return postRegisterGameService.registerGame(gameId, accessedUserId);
     }
+
+    @ExceptionHandler(RegisterGameFailed.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public RegisterGameFailedErrorDto registerGameFailed(RegisterGameFailed exception) {
+        Integer errorCode = setCodeFromMessage(exception.getMessage());
+        String errorMessage = errorCode.equals(DEFAULT)
+            ? "알 수 없는 에러입니다."
+            : exception.getMessage();
+        return new RegisterGameFailedErrorDto(errorCode, errorMessage);
+    }
+
+    private Integer setCodeFromMessage(String errorMessage) {
+        return switch (errorMessage) {
+            case "주어진 게임 번호에 해당하는 게임을 찾을 수 없습니다." -> GAME_NOT_FOUND;
+            case "이미 신청이 완료된 운동입니다." -> ALREADY_REGISTERED_GAME;
+            case "주어진 사용자 번호에 해당하는 사용자를 찾을 수 없습니다." -> USER_NOT_FOUND;
+            default -> DEFAULT;
+        };
+    }
+
 }

--- a/src/main/java/kr/megaptera/smash/dtos/RegisterGameFailedErrorDto.java
+++ b/src/main/java/kr/megaptera/smash/dtos/RegisterGameFailedErrorDto.java
@@ -1,0 +1,20 @@
+package kr.megaptera.smash.dtos;
+
+public class RegisterGameFailedErrorDto {
+    private final Integer errorCode;
+
+    private final String errorMessage;
+
+    public RegisterGameFailedErrorDto(Integer errorCode, String errorMessage) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+    }
+
+    public Integer getErrorCode() {
+        return errorCode;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+}

--- a/src/main/java/kr/megaptera/smash/exceptions/RegisterGameFailed.java
+++ b/src/main/java/kr/megaptera/smash/exceptions/RegisterGameFailed.java
@@ -1,0 +1,7 @@
+package kr.megaptera.smash.exceptions;
+
+public class RegisterGameFailed extends RuntimeException {
+    public RegisterGameFailed(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/kr/megaptera/smash/services/PostRegisterGameService.java
+++ b/src/main/java/kr/megaptera/smash/services/PostRegisterGameService.java
@@ -1,9 +1,7 @@
 package kr.megaptera.smash.services;
 
 import kr.megaptera.smash.dtos.RegisterGameResultDto;
-import kr.megaptera.smash.exceptions.AlreadyRegisteredGame;
-import kr.megaptera.smash.exceptions.GameNotFound;
-import kr.megaptera.smash.exceptions.UserNotFound;
+import kr.megaptera.smash.exceptions.RegisterGameFailed;
 import kr.megaptera.smash.models.Member;
 import kr.megaptera.smash.models.MemberName;
 import kr.megaptera.smash.models.User;
@@ -32,24 +30,22 @@ public class PostRegisterGameService {
 
     public RegisterGameResultDto registerGame(Long gameId,
                                               Long accessedUserId) {
-        // TODO: Controller에 GameNotFound Exception Handler,
-        //   AlreadyRegisteredGame Exception Handler,
-        //   UserNotFound Exception Handler 추가
-
         if (gameRepository.findById(gameId).isEmpty()) {
-            throw new GameNotFound();
+            throw new RegisterGameFailed(
+                "주어진 게임 번호에 해당하는 게임을 찾을 수 없습니다.");
         }
 
         List<Member> members = memberRepository.findByGameId(gameId);
 
         members.forEach(member -> {
             if (member.userId().equals(accessedUserId)) {
-                throw new AlreadyRegisteredGame();
+                throw new RegisterGameFailed("이미 신청이 완료된 운동입니다.");
             }
         });
 
         User user = userRepository.findById(accessedUserId)
-            .orElseThrow(UserNotFound::new);
+            .orElseThrow(() -> new RegisterGameFailed(
+                "주어진 사용자 번호에 해당하는 사용자를 찾을 수 없습니다."));
 
         Member member = new Member(
             accessedUserId,

--- a/src/test/java/kr/megaptera/smash/controllers/RegisterControllerTest.java
+++ b/src/test/java/kr/megaptera/smash/controllers/RegisterControllerTest.java
@@ -1,6 +1,7 @@
 package kr.megaptera.smash.controllers;
 
 import kr.megaptera.smash.dtos.RegisterGameResultDto;
+import kr.megaptera.smash.exceptions.RegisterGameFailed;
 import kr.megaptera.smash.services.PostRegisterGameService;
 import kr.megaptera.smash.utils.JwtUtil;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,18 +30,18 @@ class RegisterControllerTest {
 
     private String token;
 
+    private Long gameId;
     private Long userId;
 
     @BeforeEach
     void setUp() {
+        gameId = 1L;
         userId = 1L;
         token = jwtUtil.encode(userId);
     }
 
     @Test
     void registerToGame() throws Exception {
-        userId = 1L;
-        Long gameId = 1L;
         RegisterGameResultDto registerGameResultDto
             = new RegisterGameResultDto(gameId);
 
@@ -52,6 +53,55 @@ class RegisterControllerTest {
             .andExpect(MockMvcResultMatchers.status().isCreated())
             .andExpect(MockMvcResultMatchers.content().string(
                 containsString("\"gameId\":1")
+            ))
+        ;
+    }
+
+    @Test
+    void registerGameFailedWithGameNotFound() throws Exception {
+        Long wrongGameId = 222L;
+        given(postRegisterGameService.registerGame(wrongGameId, userId))
+            .willThrow(new RegisterGameFailed(
+                "주어진 게임 번호에 해당하는 게임을 찾을 수 없습니다."));
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/registers/games/222")
+                .header("Authorization", "Bearer " + token))
+            .andExpect(MockMvcResultMatchers.status().isBadRequest())
+            .andExpect(MockMvcResultMatchers.content().string(
+                containsString("100")
+            ))
+        ;
+    }
+
+    @Test
+    void registerGameFailedWithAlreadyRegisteredGame() throws Exception {
+        Long alreadyRegisteredGameId = 10L;
+        given(postRegisterGameService.registerGame(alreadyRegisteredGameId, userId))
+            .willThrow(new RegisterGameFailed(
+                "이미 신청이 완료된 운동입니다."));
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/registers/games/10")
+                .header("Authorization", "Bearer " + token))
+            .andExpect(MockMvcResultMatchers.status().isBadRequest())
+            .andExpect(MockMvcResultMatchers.content().string(
+                containsString("101")
+            ))
+        ;
+    }
+
+    @Test
+    void registerGameFailedWithUserNotFound() throws Exception {
+        Long notExistedUserId = 139L;
+        token = jwtUtil.encode(notExistedUserId);
+        given(postRegisterGameService.registerGame(gameId, notExistedUserId))
+            .willThrow(new RegisterGameFailed(
+                "주어진 사용자 번호에 해당하는 사용자를 찾을 수 없습니다."));
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/registers/games/1")
+                .header("Authorization", "Bearer " + token))
+            .andExpect(MockMvcResultMatchers.status().isBadRequest())
+            .andExpect(MockMvcResultMatchers.content().string(
+                containsString("102")
             ))
         ;
     }


### PR DESCRIPTION
에러 발생 시 에러 DTO 반환
 - RegisterGameFailedErrorDto << RegisterGameFailed
 - 발생 가능 에러
   - GameNotFound: 게시물과 연결된 게임을 찾을 수 없는 경우 발생
   - UserNotFound: 접속한 사용자 정보를 찾을 수 없는 경우 발생
   - AlreadyRegisteredGame: 사용자가 이미 게임에 참가하고 있는 경우 발생
  
문제 상황
- try, catch에서 다른 여러 종류의 exception을 모두 받아
하나의 exception으로 다시 던지는 로직으로 구현을 시도했으나 실패
```Java
catch (GameNotFound
                 | AlreadyRegisteredGame
                 | UserNotFound exception) {
            throw new RegisterGameFailed(exception.getMessage());
        }
```
일단 각각의 에러를 따로 발생시키지 않고 RegisterGameFailed로 발생 에러를 통일시키고,
전달되는 메세지를 다르게 보내도록 수정
    
알게 된 것
- verify(객체, never()).메서드() 를 이용하면 객체의 메서드가 실행되지 않았어야 함을 검증할 수 있음
  
예상 뽀모 1
사용 뽀모 2