### PR TITLE
임시 로그인 기능

### DIFF
--- a/src/main/java/kr/megaptera/smash/controllers/BackdoorController.java
+++ b/src/main/java/kr/megaptera/smash/controllers/BackdoorController.java
@@ -18,6 +18,15 @@ public class BackdoorController {
         this.jdbcTemplate = jdbcTemplate;
     }
 
+    @GetMapping("clear-posts")
+    public String emptyPosts() {
+        jdbcTemplate.execute("delete from POSTS");
+        jdbcTemplate.execute("delete from GAMES");
+        jdbcTemplate.execute("delete from MEMBERS");
+
+        return "게시물 목록 비우기 백도어 세팅이 완료되었습니다.";
+    }
+
     @GetMapping("setup-posts")
     public String setupPosts() {
         resetDatabaseForPosts();
@@ -106,5 +115,30 @@ public class BackdoorController {
         jdbcTemplate.execute("delete from GAMES");
         jdbcTemplate.execute("delete from MEMBERS");
         jdbcTemplate.execute("delete from USERS");
+    }
+
+    @GetMapping("clear-members")
+    public String emptyMembers() {
+        jdbcTemplate.execute("delete from MEMBERS");
+
+        return "운동 참가 멤버 비우기 백도어 세팅이 완료되었습니다.";
+    }
+
+    @GetMapping("setup-members")
+    public String setupMembers() {
+        jdbcTemplate.update(
+            "insert into MEMBERS(" +
+                "ID, USER_ID, GAME_ID, NAME) " +
+                "values(?, ?, ?, ?)",
+            1L, 1L, 1L, "사용자 1"
+        );
+        jdbcTemplate.update(
+            "insert into MEMBERS(" +
+                "ID, USER_ID, GAME_ID, NAME) " +
+                "values(?, ?, ?, ?)",
+            2L, 1L, 2L, "사용자 1"
+        );
+
+        return "운동 참가 멤버 백도어 세팅이 완료되었습니다.";
     }
 }

--- a/src/main/java/kr/megaptera/smash/controllers/SessionController.java
+++ b/src/main/java/kr/megaptera/smash/controllers/SessionController.java
@@ -1,0 +1,63 @@
+package kr.megaptera.smash.controllers;
+
+import com.auth0.jwt.exceptions.JWTDecodeException;
+import kr.megaptera.smash.dtos.LoginRequestDto;
+import kr.megaptera.smash.dtos.LoginFailedErrorDto;
+import kr.megaptera.smash.dtos.LoginResultDto;
+import kr.megaptera.smash.exceptions.LoginFailed;
+import kr.megaptera.smash.models.User;
+import kr.megaptera.smash.services.LoginService;
+import kr.megaptera.smash.utils.JwtUtil;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("session")
+public class SessionController {
+    private final LoginService loginService;
+    private final JwtUtil jwtUtil;
+
+    public SessionController(LoginService loginService,
+                             JwtUtil jwtUtil) {
+        this.loginService = loginService;
+        this.jwtUtil = jwtUtil;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public LoginResultDto login(
+        @Validated @RequestBody LoginRequestDto loginRequestDto,
+        BindingResult bindingResult
+    ) {
+        if (bindingResult.hasErrors()) {
+            String errorMessage = bindingResult.getAllErrors()
+                .stream()
+                .map(error -> error.getDefaultMessage())
+                .toList().get(0);
+            throw new LoginFailed(errorMessage);
+        }
+
+        Long userId = loginRequestDto.getUserId();
+        User user = loginService.verifyUser(userId);
+
+        try {
+            String accessToken = jwtUtil.encode(user.id());
+            return new LoginResultDto(accessToken);
+        } catch (JWTDecodeException exception) {
+            throw new LoginFailed("user Id 인코딩 과정에서 문제가 발생했습니다. (202)");
+        }
+    }
+
+    @ExceptionHandler(LoginFailed.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public LoginFailedErrorDto loginFailed(LoginFailed exception) {
+        return new LoginFailedErrorDto(exception.getMessage());
+    }
+}

--- a/src/main/java/kr/megaptera/smash/dtos/LoginFailedErrorDto.java
+++ b/src/main/java/kr/megaptera/smash/dtos/LoginFailedErrorDto.java
@@ -1,0 +1,13 @@
+package kr.megaptera.smash.dtos;
+
+public class LoginFailedErrorDto {
+    private final String errorMessage;
+
+    public LoginFailedErrorDto(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+}

--- a/src/main/java/kr/megaptera/smash/dtos/LoginRequestDto.java
+++ b/src/main/java/kr/megaptera/smash/dtos/LoginRequestDto.java
@@ -1,0 +1,20 @@
+package kr.megaptera.smash.dtos;
+
+import javax.validation.constraints.NotNull;
+
+public class LoginRequestDto {
+    @NotNull(message = "user Id를 입력해주세요. (200)")
+    private Long userId;
+
+    public LoginRequestDto() {
+
+    }
+
+    public LoginRequestDto(Long userId) {
+        this.userId = userId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+}

--- a/src/main/java/kr/megaptera/smash/dtos/LoginResultDto.java
+++ b/src/main/java/kr/megaptera/smash/dtos/LoginResultDto.java
@@ -1,0 +1,13 @@
+package kr.megaptera.smash.dtos;
+
+public class LoginResultDto {
+    private final String accessToken;
+
+    public LoginResultDto(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+}

--- a/src/main/java/kr/megaptera/smash/exceptions/LoginFailed.java
+++ b/src/main/java/kr/megaptera/smash/exceptions/LoginFailed.java
@@ -1,0 +1,7 @@
+package kr.megaptera.smash.exceptions;
+
+public class LoginFailed extends RuntimeException {
+    public LoginFailed(String errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/src/main/java/kr/megaptera/smash/interceptors/AuthenticationInterceptor.java
+++ b/src/main/java/kr/megaptera/smash/interceptors/AuthenticationInterceptor.java
@@ -21,8 +21,6 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
                            Object handler) throws Exception {
     String authorization = request.getHeader("Authorization");
 
-    System.out.println("authorization: " + authorization);
-
     if (authorization == null || !authorization.startsWith("Bearer ")) {
       return true;
     }

--- a/src/main/java/kr/megaptera/smash/models/User.java
+++ b/src/main/java/kr/megaptera/smash/models/User.java
@@ -32,7 +32,19 @@ public class User {
         this.gender = gender;
     }
 
+    public Long id() {
+        return id;
+    }
+
     public UserName name() {
         return name;
+    }
+
+    public static User fake(String name) {
+        return new User(
+            1L,
+            new UserName(name),
+            new UserGender("여성")
+        );
     }
 }

--- a/src/main/java/kr/megaptera/smash/services/LoginService.java
+++ b/src/main/java/kr/megaptera/smash/services/LoginService.java
@@ -1,0 +1,27 @@
+package kr.megaptera.smash.services;
+
+import kr.megaptera.smash.exceptions.LoginFailed;
+import kr.megaptera.smash.exceptions.UserNotFound;
+import kr.megaptera.smash.models.User;
+import kr.megaptera.smash.repositories.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class LoginService {
+    private final UserRepository userRepository;
+
+    public LoginService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public User verifyUser(Long userId) {
+        try {
+            return userRepository.findById(userId)
+                .orElseThrow(UserNotFound::new);
+        } catch (UserNotFound exception) {
+            throw new LoginFailed("존재하지 않는 User Id 입니다. (201)");
+        }
+    }
+}

--- a/src/test/java/kr/megaptera/smash/controllers/BackdoorControllerTest.java
+++ b/src/test/java/kr/megaptera/smash/controllers/BackdoorControllerTest.java
@@ -17,8 +17,26 @@ class BackdoorControllerTest {
     private MockMvc mockMvc;
 
     @Test
+    void clearPosts() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/backdoor/clear-posts"))
+            .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @Test
     void setupPosts() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.get("/backdoor/setup-posts"))
+            .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @Test
+    void clearMembers() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/backdoor/clear-members"))
+            .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @Test
+    void setupMembers() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/backdoor/setup-members"))
             .andExpect(MockMvcResultMatchers.status().isOk());
     }
 }

--- a/src/test/java/kr/megaptera/smash/controllers/SessionControllerTest.java
+++ b/src/test/java/kr/megaptera/smash/controllers/SessionControllerTest.java
@@ -1,0 +1,105 @@
+package kr.megaptera.smash.controllers;
+
+import com.auth0.jwt.exceptions.JWTDecodeException;
+import kr.megaptera.smash.exceptions.LoginFailed;
+import kr.megaptera.smash.models.User;
+import kr.megaptera.smash.services.LoginService;
+import kr.megaptera.smash.utils.JwtUtil;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@WebMvcTest(SessionController.class)
+class SessionControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private LoginService loginService;
+
+    @SpyBean
+    private JwtUtil jwtUtil;
+
+    @Test
+    void login() throws Exception {
+        Long userId = 1L;
+        given(loginService.verifyUser(userId)).willReturn(User.fake("사용자"));
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/session")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{" +
+                    "\"userId\":" + userId +
+                    "}"))
+            .andExpect(MockMvcResultMatchers.status().isCreated())
+        ;
+
+        verify(jwtUtil).encode(1L);
+    }
+
+    @Test
+    void loginWithEmptyUserId() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.post("/session")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{" +
+                    "\"userId\":\"\"" +
+                    "}"))
+            .andExpect(MockMvcResultMatchers.status().isBadRequest())
+            .andExpect(MockMvcResultMatchers.content().string(
+                containsString("200")
+            ))
+        ;
+    }
+
+    @Test
+    void loginWithNotExistingUserId() throws Exception {
+        Long notExistingUserId = 9999L;
+        given(loginService.verifyUser(notExistingUserId))
+            .willThrow(new LoginFailed("존재하지 않는 User Id 입니다. (201)"));
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/session")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{" +
+                    "\"userId\":" + notExistingUserId +
+                    "}"))
+            .andExpect(MockMvcResultMatchers.status().isBadRequest())
+            .andExpect(MockMvcResultMatchers.content().string(
+                containsString("201")
+            ))
+        ;
+    }
+
+    @Test
+    void loginWithEncodingError() throws Exception {
+        Long userId = 1L;
+        given(loginService.verifyUser(userId)).willReturn(User.fake("사용자"));
+        given(jwtUtil.encode(userId))
+            .willThrow(JWTDecodeException.class);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/session")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{" +
+                    "\"userId\":" + userId +
+                    "}"))
+            .andExpect(MockMvcResultMatchers.status().isBadRequest())
+            .andExpect(MockMvcResultMatchers.content().string(
+                containsString("202")
+            ))
+        ;
+
+        verify(jwtUtil).encode(1L);
+    }
+}

--- a/src/test/java/kr/megaptera/smash/services/LoginServiceTest.java
+++ b/src/test/java/kr/megaptera/smash/services/LoginServiceTest.java
@@ -1,0 +1,52 @@
+package kr.megaptera.smash.services;
+
+import kr.megaptera.smash.exceptions.LoginFailed;
+import kr.megaptera.smash.exceptions.UserNotFound;
+import kr.megaptera.smash.models.User;
+import kr.megaptera.smash.repositories.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class LoginServiceTest {
+    private UserRepository userRepository;
+    private LoginService loginService;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        loginService = new LoginService(userRepository);
+    }
+
+    @Test
+    void verifyUser() {
+        Long userId = 1L;
+        given(userRepository.findById(userId))
+            .willReturn(Optional.of(User.fake("찾아진 사용자")));
+
+        User user = loginService.verifyUser(userId);
+
+        assertThat(user).isNotNull();
+        assertThat(user.name().value()).isEqualTo("찾아진 사용자");
+
+        verify(userRepository).findById(userId);
+    }
+
+    @Test
+    void verifyUserFail() {
+        Long notExistingUserId = 9999L;
+        given(userRepository.findById(notExistingUserId))
+            .willThrow(UserNotFound.class);
+
+        assertThrows(LoginFailed.class, () -> {
+            loginService.verifyUser(notExistingUserId);
+        });
+    }
+}


### PR DESCRIPTION
인수 테스트 통과 시 명시적으로 accessToken을 설정해주기 위해
임시 로그인 기능을 작성해 인수 테스트 상에서 accessToken을 가질 수 있도록 임시 로그인 구현

SessionController
- login
  - 받은 userId로 service에서 user를 찾고, 찾은 user의 id를 jwtUtil에서 인코딩해 accessToken을 반환

LoginService
- login
  - 일단은 userId가 있는지 검사해서 있는 경우 User를 return

예상 뽀모 3
실제 뽀모 9 (프론트엔드, 백엔드 통합 기준)

이슈
- Request Body DTO에 비어 있는 생성자를 넣어주지 않아 LoginRequestDto가 생성자로 생성되지 않는 문제가 있었음
- 처음에는 jwtUtil로 인코딩만 해주면 된다고 생각해서 service가 필요 없다고 생각했는데,
  데이터베이스에 유저가 있는지 repository에서 검증해주는 과정이 있어야 했음
  (데이터베이스에 User Id가 등록된 유저만 신청/취소를 할 수 있어야 하기 때문)
  그래서 service를 설계했다가 빼고, 다시 추가하는 과정에서 비용 소요
- 예외 케이스와 그에 대한 테스트 코드를 작성하는 과정에 예상보다 많은 뽀모가 소요되었음
  
완전 로그인은 일요일에 리팩터링해서 완성하는 것으로 작업에 추가