### PR TITLE
게시글 상세 정보 보기 API 요청 처리 (GET post, game, members)

### DIFF
--- a/src/main/java/kr/megaptera/smash/controllers/GameController.java
+++ b/src/main/java/kr/megaptera/smash/controllers/GameController.java
@@ -1,0 +1,27 @@
+package kr.megaptera.smash.controllers;
+
+import kr.megaptera.smash.dtos.GameDetailDto;
+import kr.megaptera.smash.services.GetGameService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/games")
+public class GameController {
+    private final GetGameService getGameService;
+
+    public GameController(GetGameService getGameService) {
+        this.getGameService = getGameService;
+    }
+
+    @GetMapping("posts/{postId}")
+    public GameDetailDto game(
+        @RequestAttribute("userId") Long accessedUserId,
+        @PathVariable("postId") Long targetPostId
+    ) {
+        return getGameService.findTargetGame(accessedUserId, targetPostId);
+    }
+}

--- a/src/main/java/kr/megaptera/smash/controllers/MemberController.java
+++ b/src/main/java/kr/megaptera/smash/controllers/MemberController.java
@@ -1,8 +1,11 @@
 package kr.megaptera.smash.controllers;
 
+import kr.megaptera.smash.dtos.MembersDetailDto;
 import kr.megaptera.smash.services.DeleteGameMemberService;
+import kr.megaptera.smash.services.GetMembersService;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,10 +15,20 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("members")
 public class MemberController {
+    private final GetMembersService getMembersService;
     private final DeleteGameMemberService deleteGameMemberService;
 
-    public MemberController(DeleteGameMemberService deleteGameMemberService) {
+    public MemberController(GetMembersService getMembersService,
+                            DeleteGameMemberService deleteGameMemberService) {
+        this.getMembersService = getMembersService;
         this.deleteGameMemberService = deleteGameMemberService;
+    }
+
+    @GetMapping("games/{gameId}")
+    public MembersDetailDto members(
+        @PathVariable("gameId") Long targetGameId
+    ) {
+        return getMembersService.findTargetMembers(targetGameId);
     }
 
     @DeleteMapping("games/{gameId}")

--- a/src/main/java/kr/megaptera/smash/controllers/PostController.java
+++ b/src/main/java/kr/megaptera/smash/controllers/PostController.java
@@ -1,29 +1,45 @@
 package kr.megaptera.smash.controllers;
 
+import kr.megaptera.smash.dtos.PostDetailDto;
 import kr.megaptera.smash.dtos.PostsDto;
 import kr.megaptera.smash.dtos.PostsFailedErrorDto;
 import kr.megaptera.smash.exceptions.PostsFailed;
+import kr.megaptera.smash.services.GetPostService;
 import kr.megaptera.smash.services.GetPostsService;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/posts")
 public class PostController {
     private final GetPostsService getPostsService;
+    private final GetPostService getPostService;
 
-    public PostController(GetPostsService getPostsService) {
+    public PostController(GetPostsService getPostsService,
+                          GetPostService getPostService) {
         this.getPostsService = getPostsService;
+        this.getPostService = getPostService;
     }
 
-    @GetMapping("/posts")
+    @GetMapping
     public PostsDto posts(
         @RequestAttribute("userId") Long accessedUserId
     ) {
         return getPostsService.findAll(accessedUserId);
+    }
+
+    @GetMapping("/{postId}")
+    public PostDetailDto post(
+        @RequestAttribute("userId") Long accessedUserId,
+        @PathVariable("postId") Long targetPostId
+    ) {
+        return getPostService.findTargetPost(accessedUserId, targetPostId);
     }
 
     @ExceptionHandler(PostsFailed.class)

--- a/src/main/java/kr/megaptera/smash/dtos/GameDetailDto.java
+++ b/src/main/java/kr/megaptera/smash/dtos/GameDetailDto.java
@@ -1,0 +1,61 @@
+package kr.megaptera.smash.dtos;
+
+public class GameDetailDto {
+    private final Long id;
+
+    private final String type;
+
+    private final String date;
+
+    private final String place;
+
+    private final Integer currentMemberCount;
+
+    private final Integer targetMemberCount;
+
+    private final Boolean isRegistered;
+
+    public GameDetailDto(Long id,
+                         String type,
+                         String date,
+                         String place,
+                         Integer currentMemberCount,
+                         Integer targetMemberCount,
+                         Boolean isRegistered) {
+        this.id = id;
+        this.type = type;
+        this.date = date;
+        this.place = place;
+        this.currentMemberCount = currentMemberCount;
+        this.targetMemberCount = targetMemberCount;
+        this.isRegistered = isRegistered;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getDate() {
+        return date;
+    }
+
+    public String getPlace() {
+        return place;
+    }
+
+    public Integer getCurrentMemberCount() {
+        return currentMemberCount;
+    }
+
+    public Integer getTargetMemberCount() {
+        return targetMemberCount;
+    }
+
+    public Boolean getIsRegistered() {
+        return isRegistered;
+    }
+}

--- a/src/main/java/kr/megaptera/smash/dtos/MemberDetailDto.java
+++ b/src/main/java/kr/megaptera/smash/dtos/MemberDetailDto.java
@@ -1,0 +1,37 @@
+package kr.megaptera.smash.dtos;
+
+public class MemberDetailDto {
+    private final Long id;
+
+    private final String name;
+
+    private final String gender;
+
+    private final String phoneNumber;
+
+    public MemberDetailDto(Long id,
+                           String name,
+                           String gender,
+                           String phoneNumber) {
+        this.id = id;
+        this.name = name;
+        this.gender = gender;
+        this.phoneNumber = phoneNumber;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getGender() {
+        return gender;
+    }
+
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+}

--- a/src/main/java/kr/megaptera/smash/dtos/MembersDetailDto.java
+++ b/src/main/java/kr/megaptera/smash/dtos/MembersDetailDto.java
@@ -1,0 +1,15 @@
+package kr.megaptera.smash.dtos;
+
+import java.util.List;
+
+public class MembersDetailDto {
+    private final List<MemberDetailDto> members;
+
+    public MembersDetailDto(List<MemberDetailDto> members) {
+        this.members = members;
+    }
+
+    public List<MemberDetailDto> getMembers() {
+        return members;
+    }
+}

--- a/src/main/java/kr/megaptera/smash/dtos/PostDetailDto.java
+++ b/src/main/java/kr/megaptera/smash/dtos/PostDetailDto.java
@@ -1,0 +1,54 @@
+package kr.megaptera.smash.dtos;
+
+public class PostDetailDto {
+    private final Long id;
+
+    private final Long hits;
+
+    private final String authorName;
+
+    private final String authorPhoneNumber;
+
+    private final String detail;
+
+    private final Boolean isAuthor;
+
+    public PostDetailDto(Long id,
+                         Long hits,
+                         String authorName,
+                         String authorPhoneNumber,
+                         String detail,
+                         Boolean isAuthor
+    ) {
+        this.id = id;
+        this.hits = hits;
+        this.authorName = authorName;
+        this.authorPhoneNumber = authorPhoneNumber;
+        this.detail = detail;
+        this.isAuthor = isAuthor;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getHits() {
+        return hits;
+    }
+
+    public String getAuthorName() {
+        return authorName;
+    }
+
+    public String getAuthorPhoneNumber() {
+        return authorPhoneNumber;
+    }
+
+    public String getDetail() {
+        return detail;
+    }
+
+    public Boolean getIsAuthor() {
+        return isAuthor;
+    }
+}

--- a/src/main/java/kr/megaptera/smash/models/Game.java
+++ b/src/main/java/kr/megaptera/smash/models/Game.java
@@ -90,6 +90,17 @@ public class Game {
         return games;
     }
 
+    public static Game fake(String exerciseName, String placeName) {
+        return new Game(
+            1L,
+            1L,
+            new Exercise(exerciseName),
+            new GameDate("경기 날짜"),
+            new Place(placeName),
+            new GameTargetMemberCount(10)
+        );
+    }
+
     public GameInPostListDto toGameInPostListDto(Integer currentMemberCount,
                                                  Boolean isRegistered) {
         return new GameInPostListDto(

--- a/src/main/java/kr/megaptera/smash/models/Member.java
+++ b/src/main/java/kr/megaptera/smash/models/Member.java
@@ -46,6 +46,10 @@ public class Member {
         this.name = name;
     }
 
+    public Long id() {
+        return id;
+    }
+
     public Long userId() {
         return userId;
     }

--- a/src/main/java/kr/megaptera/smash/models/Post.java
+++ b/src/main/java/kr/megaptera/smash/models/Post.java
@@ -25,8 +25,13 @@ public class Post {
     @GeneratedValue
     private Long id;
 
+    private Long userId;
+
     @Embedded
     private PostHits hits;
+
+    @Embedded
+    private PostDetail detail;
 
     @CreationTimestamp
     private LocalDateTime createdAt;
@@ -39,19 +44,27 @@ public class Post {
     }
 
     public Post(Long id,
-                PostHits hits
+                Long userId,
+                PostHits hits,
+                PostDetail detail
     ) {
         this.id = id;
+        this.userId = userId;
         this.hits = hits;
+        this.detail = detail;
     }
 
     public Post(Long id,
+                Long userId,
                 PostHits hits,
+                PostDetail detail,
                 LocalDateTime createdAt,
                 LocalDateTime updatedAt
     ) {
         this.id = id;
+        this.userId = userId;
         this.hits = hits;
+        this.detail = detail;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
@@ -60,8 +73,27 @@ public class Post {
         return id;
     }
 
+    public Long userId() {
+        return userId;
+    }
+
     public PostHits hits() {
         return hits;
+    }
+
+    public PostDetail detail() {
+        return detail;
+    }
+
+    public static Post fake(String detail) {
+        return new Post(
+            1L,
+            1L,
+            new PostHits(1234L),
+            new PostDetail(detail),
+            LocalDateTime.now(),
+            LocalDateTime.now()
+        );
     }
 
     public static List<Post> fakes(long generationCount) {
@@ -69,7 +101,9 @@ public class Post {
         for (long id = 1; id <= generationCount; id += 1) {
             Post post = new Post(
                 id,
+                1L,
                 new PostHits(123L),
+                new PostDetail("게시글 상세 정보 내용입니다."),
                 LocalDateTime.now(),
                 LocalDateTime.now()
             );

--- a/src/main/java/kr/megaptera/smash/models/PostDetail.java
+++ b/src/main/java/kr/megaptera/smash/models/PostDetail.java
@@ -1,0 +1,43 @@
+package kr.megaptera.smash.models;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import java.util.Objects;
+
+@Embeddable
+public class PostDetail {
+    @Column(name = "detail")
+    private String value;
+
+    private PostDetail() {
+
+    }
+
+    public PostDetail(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PostDetail that = (PostDetail) o;
+        return Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+
+    @Override
+    public String toString() {
+        return "PostDetail{" +
+            "value='" + value + '\'' +
+            '}';
+    }
+}

--- a/src/main/java/kr/megaptera/smash/models/User.java
+++ b/src/main/java/kr/megaptera/smash/models/User.java
@@ -5,6 +5,8 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "users")
@@ -19,17 +21,36 @@ public class User {
     @Embedded
     private UserGender gender;
 
+    @Embedded
+    private UserPhoneNumber phoneNumber;
+
     private User() {
 
     }
 
     public User(Long id,
                 UserName name,
-                UserGender gender
+                UserGender gender,
+                UserPhoneNumber phoneNumber
     ) {
         this.id = id;
         this.name = name;
         this.gender = gender;
+        this.phoneNumber = phoneNumber;
+    }
+
+    public static List<User> fakes(long generationCount) {
+        List<User> users = new ArrayList<>();
+        for (long id = 1; id <= generationCount; id += 1) {
+            User user = new User(
+                id,
+                new UserName("사용자 " + id),
+                new UserGender("성별"),
+                new UserPhoneNumber("010-0000-0000")
+            );
+            users.add(user);
+        }
+        return users;
     }
 
     public Long id() {
@@ -40,11 +61,20 @@ public class User {
         return name;
     }
 
+    public UserGender gender() {
+        return gender;
+    }
+
+    public UserPhoneNumber phoneNumber() {
+        return phoneNumber;
+    }
+
     public static User fake(String name) {
         return new User(
             1L,
             new UserName(name),
-            new UserGender("여성")
+            new UserGender("여성"),
+            new UserPhoneNumber("010-8888-8888")
         );
     }
 }

--- a/src/main/java/kr/megaptera/smash/models/UserPhoneNumber.java
+++ b/src/main/java/kr/megaptera/smash/models/UserPhoneNumber.java
@@ -1,0 +1,43 @@
+package kr.megaptera.smash.models;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import java.util.Objects;
+
+@Embeddable
+public class UserPhoneNumber {
+    @Column(name = "phone_number")
+    private String value;
+
+    private UserPhoneNumber() {
+
+    }
+
+    public UserPhoneNumber(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        UserPhoneNumber that = (UserPhoneNumber) o;
+        return Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+
+    @Override
+    public String toString() {
+        return "UserPhoneNumber{" +
+            "value='" + value + '\'' +
+            '}';
+    }
+}

--- a/src/main/java/kr/megaptera/smash/repositories/MemberRepository.java
+++ b/src/main/java/kr/megaptera/smash/repositories/MemberRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
     List<Member> findByGameId(Long gameId);
     Optional<Member> findByGameIdAndUserId(Long gameId, Long userId);
+    List<Member> findAllByGameId(Long gameId);
 }

--- a/src/main/java/kr/megaptera/smash/services/GetGameService.java
+++ b/src/main/java/kr/megaptera/smash/services/GetGameService.java
@@ -1,0 +1,46 @@
+package kr.megaptera.smash.services;
+
+import kr.megaptera.smash.dtos.GameDetailDto;
+import kr.megaptera.smash.exceptions.GameNotFound;
+import kr.megaptera.smash.models.Game;
+import kr.megaptera.smash.models.Member;
+import kr.megaptera.smash.repositories.GameRepository;
+import kr.megaptera.smash.repositories.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class GetGameService {
+    private final GameRepository gameRepository;
+    private final MemberRepository memberRepository;
+
+    public GetGameService(GameRepository gameRepository,
+                          MemberRepository memberRepository) {
+        this.gameRepository = gameRepository;
+        this.memberRepository = memberRepository;
+    }
+
+    public GameDetailDto findTargetGame(Long accessedUserId,
+                                        Long targetPostId) {
+        Game game = gameRepository.findByPostId(targetPostId)
+            .orElseThrow(GameNotFound::new);
+
+        List<Member> members = memberRepository.findAllByGameId(game.id());
+
+        Boolean isRegistered = members.stream()
+            .anyMatch(member -> member.userId().equals(accessedUserId));
+
+        return new GameDetailDto(
+            game.id(),
+            game.exercise().name(),
+            game.date().value(),
+            game.place().name(),
+            members.size(),
+            game.targetMemberCount().value(),
+            isRegistered
+        );
+    }
+}

--- a/src/main/java/kr/megaptera/smash/services/GetMembersService.java
+++ b/src/main/java/kr/megaptera/smash/services/GetMembersService.java
@@ -1,0 +1,45 @@
+package kr.megaptera.smash.services;
+
+import kr.megaptera.smash.dtos.MemberDetailDto;
+import kr.megaptera.smash.dtos.MembersDetailDto;
+import kr.megaptera.smash.exceptions.UserNotFound;
+import kr.megaptera.smash.models.Member;
+import kr.megaptera.smash.models.User;
+import kr.megaptera.smash.repositories.MemberRepository;
+import kr.megaptera.smash.repositories.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class GetMembersService {
+    private final MemberRepository memberRepository;
+    private final UserRepository userRepository;
+
+    public GetMembersService(MemberRepository memberRepository,
+                             UserRepository userRepository) {
+        this.memberRepository = memberRepository;
+        this.userRepository = userRepository;
+    }
+
+    public MembersDetailDto findTargetMembers(Long targetGameId) {
+        List<Member> members = memberRepository.findAllByGameId(targetGameId);
+
+        List<MemberDetailDto> memberDetailDtos = members.stream()
+            .map(member -> {
+                User user = userRepository.findById(member.userId())
+                    .orElseThrow(UserNotFound::new);
+                return new MemberDetailDto(
+                    member.id(),
+                    user.name().value(),
+                    user.gender().value(),
+                    user.phoneNumber().value()
+                );
+            })
+            .toList();
+
+        return new MembersDetailDto(memberDetailDtos);
+    }
+}

--- a/src/main/java/kr/megaptera/smash/services/GetPostService.java
+++ b/src/main/java/kr/megaptera/smash/services/GetPostService.java
@@ -1,0 +1,46 @@
+package kr.megaptera.smash.services;
+
+import kr.megaptera.smash.dtos.PostDetailDto;
+import kr.megaptera.smash.exceptions.PostNotFound;
+import kr.megaptera.smash.exceptions.UserNotFound;
+import kr.megaptera.smash.models.Post;
+import kr.megaptera.smash.models.User;
+import kr.megaptera.smash.repositories.PostRepository;
+import kr.megaptera.smash.repositories.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class GetPostService {
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+
+    public GetPostService(PostRepository postRepository,
+                          UserRepository userRepository) {
+        this.postRepository = postRepository;
+        this.userRepository = userRepository;
+    }
+
+    public PostDetailDto findTargetPost(Long accessedUserId,
+                                        Long targetPostId) {
+        Post post = postRepository.findById(targetPostId)
+            .orElseThrow(PostNotFound::new);
+
+        Long authorId = post.userId();
+
+        User user = userRepository.findById(authorId)
+            .orElseThrow(UserNotFound::new);
+
+        Boolean isAuthor = authorId.equals(accessedUserId);
+
+        return new PostDetailDto(
+            post.id(),
+            post.hits().value(),
+            user.name().value(),
+            user.phoneNumber().value(),
+            post.detail().value(),
+            isAuthor
+        );
+    }
+}

--- a/src/test/java/kr/megaptera/smash/controllers/GameControllerTest.java
+++ b/src/test/java/kr/megaptera/smash/controllers/GameControllerTest.java
@@ -1,0 +1,71 @@
+package kr.megaptera.smash.controllers;
+
+import kr.megaptera.smash.dtos.GameDetailDto;
+import kr.megaptera.smash.models.Game;
+import kr.megaptera.smash.models.Member;
+import kr.megaptera.smash.services.GetGameService;
+import kr.megaptera.smash.utils.JwtUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.BDDMockito.given;
+
+@WebMvcTest(GameController.class)
+class GameControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private GetGameService getGameService;
+
+    private GameDetailDto gameDetailDto;
+
+    @SpyBean
+    private JwtUtil jwtUtil;
+
+    private String token;
+
+    private Long userId = 1L;
+    private Long targetPostId = 1L;
+
+    @BeforeEach
+    void setUp() {
+        token = jwtUtil.encode(userId);
+
+        Game game = Game.fake("스케이트", "Mokdong Ice Rink");
+        List<Member> members = Member.fakes(5, game.id());
+        Boolean isNotRegistered = false;
+        gameDetailDto = new GameDetailDto(
+            game.id(),
+            game.exercise().name(),
+            game.date().value(),
+            game.place().name(),
+            members.size(),
+            game.targetMemberCount().value(),
+            isNotRegistered
+        );
+    }
+
+    @Test
+    void game() throws Exception {
+        given(getGameService.findTargetGame(userId, targetPostId))
+            .willReturn(gameDetailDto);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/games/posts/1")
+                .header("Authorization", "Bearer " + token))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.content().string(
+                containsString("\"place\":\"Mokdong Ice Rink\"")
+            ));
+    }
+}

--- a/src/test/java/kr/megaptera/smash/controllers/MemberControllerTest.java
+++ b/src/test/java/kr/megaptera/smash/controllers/MemberControllerTest.java
@@ -1,6 +1,11 @@
 package kr.megaptera.smash.controllers;
 
+import kr.megaptera.smash.dtos.MemberDetailDto;
+import kr.megaptera.smash.dtos.MembersDetailDto;
+import kr.megaptera.smash.models.Member;
+import kr.megaptera.smash.models.User;
 import kr.megaptera.smash.services.DeleteGameMemberService;
+import kr.megaptera.smash.services.GetMembersService;
 import kr.megaptera.smash.utils.JwtUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,6 +17,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 @WebMvcTest(MemberController.class)
@@ -19,31 +28,68 @@ class MemberControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
+    // GET members/gameId
+    @MockBean
+    private GetMembersService getMembersService;
+
+    private List<MemberDetailDto> memberDetailDtos;
+    private MembersDetailDto membersDetailDto;
+
+    // DELETE members/gameId
     @MockBean
     private DeleteGameMemberService deleteGameMemberService;
 
+    // stubs
     @SpyBean
     private JwtUtil jwtUtil;
 
     private String token;
 
     private Long userId;
+    private Long targetGameId = 1L;
 
     @BeforeEach
     void setUp() {
         userId = 1L;
         token = jwtUtil.encode(userId);
+
+        // GET members/gameId
+        List<Member> members = Member.fakes(5, targetGameId);
+        List<User> users = User.fakes(5);
+        memberDetailDtos = members.stream()
+            .map(member -> {
+                User matchedUser = users.stream()
+                    .filter(user -> user.id().equals(member.id()))
+                    .findFirst().get();
+                return new MemberDetailDto(
+                    member.id(),
+                    matchedUser.name().value(),
+                    matchedUser.gender().value(),
+                    matchedUser.phoneNumber().value()
+                );
+            })
+            .toList();
+        membersDetailDto = new MembersDetailDto(memberDetailDtos);
+    }
+
+    @Test
+    void members() throws Exception {
+        given(getMembersService.findTargetMembers(targetGameId))
+            .willReturn(membersDetailDto);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/members/games/1"))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.content().string(
+                containsString("\"phoneNumber\":\"010-0000-0000\"")
+            ));
     }
 
     @Test
     void deleteMember() throws Exception {
-        userId = 1L;
-        Long gameId = 1L;
-
         mockMvc.perform(MockMvcRequestBuilders.delete("/members/games/1")
                 .header("Authorization", "Bearer " + token))
             .andExpect(MockMvcResultMatchers.status().isNoContent());
 
-        verify(deleteGameMemberService).deleteGameMember(userId, gameId);
+        verify(deleteGameMemberService).deleteGameMember(userId, targetGameId);
     }
 }

--- a/src/test/java/kr/megaptera/smash/services/GetGameServiceTest.java
+++ b/src/test/java/kr/megaptera/smash/services/GetGameServiceTest.java
@@ -1,0 +1,64 @@
+package kr.megaptera.smash.services;
+
+import kr.megaptera.smash.dtos.GameDetailDto;
+import kr.megaptera.smash.models.Exercise;
+import kr.megaptera.smash.models.Game;
+import kr.megaptera.smash.models.GameDate;
+import kr.megaptera.smash.models.GameTargetMemberCount;
+import kr.megaptera.smash.models.Member;
+import kr.megaptera.smash.models.Place;
+import kr.megaptera.smash.repositories.GameRepository;
+import kr.megaptera.smash.repositories.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+class GetGameServiceTest {
+    private GetGameService getGameService;
+
+    private GameRepository gameRepository;
+    private MemberRepository memberRepository;
+
+    @BeforeEach
+    void setUp() {
+        gameRepository = mock(GameRepository.class);
+        memberRepository = mock(MemberRepository.class);
+
+        getGameService = new GetGameService(gameRepository, memberRepository);
+    }
+
+    @Test
+    void findTargetGame() {
+        Long gameId = 1L;
+        Long postId = 1L;
+        Game game = new Game(
+            gameId,
+            postId,
+            new Exercise("야구"),
+            new GameDate("2022년 8월 21일 19:00~22:00"),
+            new Place("목동야구장"),
+            new GameTargetMemberCount(10)
+        );
+        List<Member> members = Member.fakes(8, 1L);
+        Long targetPostId = 1L;
+        Long accessedUserId = 10L;
+
+        given(gameRepository.findByPostId(targetPostId))
+            .willReturn(Optional.of(game));
+        given(memberRepository.findAllByGameId(game.id()))
+            .willReturn(members);
+
+        GameDetailDto gameDetailDto
+            = getGameService.findTargetGame(accessedUserId, targetPostId);
+
+        assertThat(gameDetailDto).isNotNull();
+        assertThat(gameDetailDto.getCurrentMemberCount()).isEqualTo(8);
+        assertThat(gameDetailDto.getIsRegistered()).isFalse();
+    }
+}

--- a/src/test/java/kr/megaptera/smash/services/GetMembersServiceTest.java
+++ b/src/test/java/kr/megaptera/smash/services/GetMembersServiceTest.java
@@ -1,0 +1,52 @@
+package kr.megaptera.smash.services;
+
+import kr.megaptera.smash.dtos.MemberDetailDto;
+import kr.megaptera.smash.dtos.MembersDetailDto;
+import kr.megaptera.smash.models.Member;
+import kr.megaptera.smash.models.User;
+import kr.megaptera.smash.repositories.MemberRepository;
+import kr.megaptera.smash.repositories.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+class GetMembersServiceTest {
+    private GetMembersService getMembersService;
+
+    private MemberRepository memberRepository;
+    private UserRepository userRepository;
+
+    @BeforeEach
+    void setUp() {
+        memberRepository = mock(MemberRepository.class);
+        userRepository = mock(UserRepository.class);
+        getMembersService
+            = new GetMembersService(memberRepository,userRepository);
+    }
+
+    @Test
+    void findTargetMembers() {
+        Long targetGameId = 1L;
+        List<Member> members = Member.fakes(2, targetGameId);
+        List<User> users = User.fakes(2);
+
+        given(memberRepository.findAllByGameId(targetGameId))
+            .willReturn(members);
+        given(userRepository.findById(members.get(0).userId()))
+            .willReturn(Optional.of(users.get(0)));
+        given(userRepository.findById(members.get(1).userId()))
+            .willReturn(Optional.of(users.get(1)));
+
+        MembersDetailDto membersDetailDto
+            = getMembersService.findTargetMembers(targetGameId);
+
+        assertThat(membersDetailDto).isNotNull();
+        assertThat(membersDetailDto.getMembers().size()).isEqualTo(2);
+    }
+}

--- a/src/test/java/kr/megaptera/smash/services/GetPostServiceTest.java
+++ b/src/test/java/kr/megaptera/smash/services/GetPostServiceTest.java
@@ -1,0 +1,71 @@
+package kr.megaptera.smash.services;
+
+import kr.megaptera.smash.dtos.PostDetailDto;
+import kr.megaptera.smash.models.Post;
+import kr.megaptera.smash.models.PostDetail;
+import kr.megaptera.smash.models.PostHits;
+import kr.megaptera.smash.models.User;
+import kr.megaptera.smash.models.UserGender;
+import kr.megaptera.smash.models.UserName;
+import kr.megaptera.smash.models.UserPhoneNumber;
+import kr.megaptera.smash.repositories.PostRepository;
+import kr.megaptera.smash.repositories.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class GetPostServiceTest {
+    private PostRepository postRepository;
+    private UserRepository userRepository;
+
+    private GetPostService getPostService;
+
+    @BeforeEach
+    void setUp() {
+        postRepository = mock(PostRepository.class);
+        userRepository = mock(UserRepository.class);
+        getPostService = new GetPostService(postRepository, userRepository);
+    }
+
+    @Test
+    void findTargetPostWhenIsAuthor() {
+        Long postId = 1L;
+        Long userId = 1L;
+        Post post = new Post(
+            postId,
+            userId,
+            new PostHits(1234L),
+            new PostDetail("평일 오전 볼링 내기 ㄱ?"),
+            LocalDateTime.now(),
+            LocalDateTime.now()
+        );
+        User user = new User(
+            userId,
+            new UserName("볼링맨"),
+            new UserGender("남성"),
+            new UserPhoneNumber("010-8888-8888")
+        );
+        Long targetPostId = 1L;
+        Long accessedUserId = 1L;
+
+        given(postRepository.findById(targetPostId)).willReturn(Optional.of(post));
+        given(userRepository.findById(post.id())).willReturn(Optional.of(user));
+
+        PostDetailDto postDetailDto
+            = getPostService.findTargetPost(accessedUserId, targetPostId);
+
+        assertThat(postDetailDto).isNotNull();
+        assertThat(postDetailDto.getAuthorName()).isEqualTo("볼링맨");
+        assertThat(postDetailDto.getIsAuthor()).isEqualTo(true);
+
+        verify(postRepository).findById(targetPostId);
+        verify(userRepository).findById(post.id());
+    }
+}

--- a/src/test/java/kr/megaptera/smash/services/PostRegisterGameServiceTest.java
+++ b/src/test/java/kr/megaptera/smash/services/PostRegisterGameServiceTest.java
@@ -12,6 +12,7 @@ import kr.megaptera.smash.models.Place;
 import kr.megaptera.smash.models.User;
 import kr.megaptera.smash.models.UserGender;
 import kr.megaptera.smash.models.UserName;
+import kr.megaptera.smash.models.UserPhoneNumber;
 import kr.megaptera.smash.repositories.GameRepository;
 import kr.megaptera.smash.repositories.MemberRepository;
 import kr.megaptera.smash.repositories.UserRepository;
@@ -69,11 +70,21 @@ class PostRegisterGameServiceTest {
         given(memberRepository.findByGameId(gameId)).willReturn(members);
 
         Long userId = 1L;
-        User user = new User(userId, new UserName("사용자명"), new UserGender("남성"));
+        User user = new User(
+            userId,
+            new UserName("사용자명"),
+            new UserGender("남성"),
+            new UserPhoneNumber("010-2222-2222")
+        );
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
-        Member registeredMember = new Member(3L, userId, gameId, new MemberName(user.name().value()));
-        given(memberRepository.save(any(Member.class))).willReturn(registeredMember);
+        Member registeredMember = new Member(3L,
+            userId,
+            gameId,
+            new MemberName(user.name().value())
+        );
+        given(memberRepository.save(any(Member.class)))
+            .willReturn(registeredMember);
 
         RegisterGameResultDto registerGameResultDto
             = postRegisterGameService.registerGame(gameId, userId);


### PR DESCRIPTION
총 3번의 API 요청은 모두
- header로 받는 Access Token을 식별해 접속한 user Id를 판별
- pathVariable로 post 혹은 game Id를 판별
- 각 DTO 양식은 msw에서 지정한 양식에 맞춰 작성

GET /posts/{post_id}
- PostController
  - 성공: PostDetailDto 반환
  - 실패: PostFailedErrorDto 반환
- GetPostService
  - Post를 찾아 데이터들을 PostDetailDto에 추가
  - Post의 userId로 User 검색: 작성자
  - 작성자 이름, 연락처를 PostDetailDto에 추가
  - accessedUserId와 Post의 userId를 비교해 isAuthor를 결정해 PostDetailDto에 추가
- Post
  - userId 필드 추가: 작성자 식별  
  
GET /games/{post_id}
- GameController
  - 성공: GameDetailDto 반환
  - 실패: PostFailedErrorDto 반환
- GetGameService
  - postId로 Game을 찾아 데이터들을 GameDetailDto에 추가
  - Game의 gameId로 Members 검색: 참가자들
  - Members의 size를 currentMemberCount로 GameDetailDto에 추가
  - 일단은 isRegistered는 Members의 userId에 accessedUser가 있으면
    true로 GameDetailDto에 추가 (신청 모델 정의 시에는 신청 모델에 있어야 추가되도록 해야 함)

GET /members/{game_id}
- MemberController
  - 성공: MembersDetailDto 반환
  - 실패: PostFailedErrorDto 반환
- GetMembersService
  - gameId를 갖는 Member 컬렉션들을 찾음
  - 각 Member들을 stream을 돌면서 userId에 해당하는 User를 찾고,
    User의 id, name, phoneNumber로 MemberDetailDto를 생성해 컬렉션으로 변환
    컬력션을 MembersDetailDto으로 변환
  
다른 Task에서 진행해야 할 작업 사항
- GameDetailDto에 추가하는 신청 모델 정의 시 isRegistered 판별을 신청 모델에 있어야 true가 되도록 해야 함

특이사항
- 내용만 보여줄 것이기 때문에 exception과 관련된 처리는 상세 조회를 리팩터링하면서 하기로 결정

예상 뽀모 6
사용 뽀모 9

회고
msw의 응답을 작성할 때, DTO의 형태에 맞춘다면 context.json은
```JavaScript
context.json(
  post: {
    id: 1,
    hits: 223,
  }
),
```
이런 형태가 아니라,
```JavaScript
context.json({
  id: 1,
  hits: 223,
  authorName: '작성자',
  authorPhoneNumber: '010-1111-2222',
  detail: '점심먹고 가볍게 탁구하실분?',
  isAuthor: true,
}),
```
이런 형태여야 함