### PR TITLE
UserAccount 값 객체 추가, 로그인 기능 리팩터링 및 예외처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'com.auth0:java-jwt:4.2.1'
+	implementation 'org.bouncycastle:bcprov-jdk15on:1.70'
 
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 

--- a/src/main/java/kr/megaptera/smash/SmashApplication.java
+++ b/src/main/java/kr/megaptera/smash/SmashApplication.java
@@ -8,6 +8,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -43,7 +46,8 @@ public class SmashApplication {
                         HttpMethod.GET.name(),
                         HttpMethod.POST.name(),
                         HttpMethod.PATCH.name()
-                    );
+                    )
+                ;
             }
         };
     }
@@ -56,5 +60,10 @@ public class SmashApplication {
     @Bean
     public JwtUtil jwtUtil() {
         return new JwtUtil(jwtSecret);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new Argon2PasswordEncoder();
     }
 }

--- a/src/main/java/kr/megaptera/smash/config/MockMvcEncoding.java
+++ b/src/main/java/kr/megaptera/smash/config/MockMvcEncoding.java
@@ -1,0 +1,19 @@
+package kr.megaptera.smash.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Import(MockMvcEncoding.Config.class)
+public @interface MockMvcEncoding {
+    class Config {
+        @Bean
+        public CharacterEncodingFilter characterEncodingFilter() {
+            return new CharacterEncodingFilter("UTF-8", true);
+        }
+    }
+}

--- a/src/main/java/kr/megaptera/smash/controllers/BackdoorController.java
+++ b/src/main/java/kr/megaptera/smash/controllers/BackdoorController.java
@@ -2,6 +2,7 @@ package kr.megaptera.smash.controllers;
 
 import kr.megaptera.smash.models.RegisterStatus;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,9 +15,40 @@ import java.time.LocalDateTime;
 @Transactional
 public class BackdoorController {
     private final JdbcTemplate jdbcTemplate;
+    private final PasswordEncoder passwordEncoder;
 
-    public BackdoorController(JdbcTemplate jdbcTemplate) {
+    public BackdoorController(JdbcTemplate jdbcTemplate,
+                              PasswordEncoder passwordEncoder) {
         this.jdbcTemplate = jdbcTemplate;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    private void resetDatabase() {
+        jdbcTemplate.execute("delete from POSTS");
+        jdbcTemplate.execute("delete from GAMES");
+        jdbcTemplate.execute("delete from REGISTERS");
+        jdbcTemplate.execute("delete from USERS");
+    }
+
+    private void resetRegisters() {
+        jdbcTemplate.execute("delete from REGISTERS");
+    }
+
+    private void resetUsers() {
+        jdbcTemplate.execute("delete from USERS");
+    }
+
+    private void setUpUsers(long startId, long endId) {
+        for (long id = startId; id <= endId; id += 1) {
+            jdbcTemplate.update(
+                "insert into USERS(" +
+                    "ID, IDENTIFIER, PASSWORD, NAME, GENDER, PHONE_NUMBER) " +
+                    "values(?, ?, ?, ?, ?, ?)",
+                id, "identifier" + id, passwordEncoder.encode("Password!" + id),
+                "사용자 " + id, "남성",
+                "010-0000-000" + id
+            );
+        }
     }
 
     @GetMapping("clear-posts")
@@ -30,42 +62,162 @@ public class BackdoorController {
 
     @GetMapping("setup-posts")
     public String setupPosts() {
-        resetDatabaseForPosts();
-
-        // TODO: 변경된 모델의 column에 맞게 backdoor도 바뀌어야 함!!!!!
+        resetDatabase();
 
         jdbcTemplate.update(
             "insert into POSTS(" +
-                "ID, HITS, CREATED_AT, UPDATED_AT) " +
-                "values(?, ?, ?, ?)",
-            1L, 123L, LocalDateTime.now(), LocalDateTime.now()
-        );
-        jdbcTemplate.update(
-            "insert into POSTS(" +
-                "ID, HITS, CREATED_AT, UPDATED_AT) " +
-                "values(?, ?, ?, ?)",
-            2L, 5593L, LocalDateTime.now(), LocalDateTime.now()
-        );
-
-        jdbcTemplate.update(
-            "insert into GAMES(" +
-                "ID, POST_ID, EXERCISE_NAME, DATE, PLACE_NAME, TARGET_MEMBER_COUNT) " +
+                "ID, USER_ID, HITS, CREATED_AT, UPDATED_AT, DETAIL) " +
                 "values(?, ?, ?, ?, ?, ?)",
-            1L, 1L, "축구", "2022년 11월 13일 15:00~17:00", "잠실종합운동장", 24
+            1L, 1L, 123L, LocalDateTime.now(), LocalDateTime.now(),
+            "축구 인원 모집 게시글입니다."
         );
         jdbcTemplate.update(
             "insert into GAMES(" +
                 "ID, POST_ID, EXERCISE_NAME, DATE, PLACE_NAME, TARGET_MEMBER_COUNT) " +
                 "values(?, ?, ?, ?, ?, ?)",
-            2L, 2L, "배구", "2022년 11월 14일 15:00~17:00", "장충체육관", 12
+            1L, 1L, "축구", "2022년 11월 13일 15:00~17:00", "잠실종합운동장", 4
+        );
+        jdbcTemplate.update(
+            "insert into POSTS(" +
+                "ID, USER_ID, HITS, CREATED_AT, UPDATED_AT, DETAIL) " +
+                "values(?, ?, ?, ?, ?, ?)",
+            2L, 1L, 5593L, LocalDateTime.now(), LocalDateTime.now(),
+            "배구 인원 모집 게시글입니다."
+        );
+        jdbcTemplate.update(
+            "insert into GAMES(" +
+                "ID, POST_ID, EXERCISE_NAME, DATE, PLACE_NAME, TARGET_MEMBER_COUNT) " +
+                "values(?, ?, ?, ?, ?, ?)",
+            2L, 2L, "배구", "2022년 11월 14일 15:00~17:00", "장충체육관", 4
         );
 
+        return "게시물 목록 백도어 세팅이 완료되었습니다.";
+    }
+
+    @GetMapping("setup-members-posts")
+    public String setupMembersPosts() {
+        resetRegisters();
+        resetUsers();
+
+        // set author
+        jdbcTemplate.update(
+            "insert into USERS(" +
+                "ID, IDENTIFIER, PASSWORD, NAME, GENDER, PHONE_NUMBER) " +
+                "values(?, ?, ?, ?, ?, ?)",
+            1L, "identifier1", passwordEncoder.encode("Password!1"),
+            "작성자 이름", "남성", "010-0000-0001"
+        );
         jdbcTemplate.update(
             "insert into REGISTERS(" +
                 "ID, USER_ID, GAME_ID, STATUS) " +
                 "values(?, ?, ?, ?)",
             1L, 1L, 1L, RegisterStatus.ACCEPTED
         );
+        jdbcTemplate.update(
+            "insert into REGISTERS(" +
+                "ID, USER_ID, GAME_ID, STATUS) " +
+                "values(?, ?, ?, ?)",
+            2L, 1L, 2L, RegisterStatus.ACCEPTED
+        );
+
+        setUpUsers(2, 6);
+
+        jdbcTemplate.update(
+            "insert into REGISTERS(" +
+                "ID, USER_ID, GAME_ID, STATUS) " +
+                "values(?, ?, ?, ?)",
+            3L, 3L, 1L, RegisterStatus.ACCEPTED
+        );
+        jdbcTemplate.update(
+            "insert into REGISTERS(" +
+                "ID, USER_ID, GAME_ID, STATUS) " +
+                "values(?, ?, ?, ?)",
+            4L, 4L, 1L, RegisterStatus.PROCESSING
+        );
+        jdbcTemplate.update(
+            "insert into REGISTERS(" +
+                "ID, USER_ID, GAME_ID, STATUS) " +
+                "values(?, ?, ?, ?)",
+            5L, 5L, 1L, RegisterStatus.CANCELED
+        );
+        jdbcTemplate.update(
+            "insert into REGISTERS(" +
+                "ID, USER_ID, GAME_ID, STATUS) " +
+                "values(?, ?, ?, ?)",
+            6L, 6L, 2L, RegisterStatus.ACCEPTED
+        );
+
+        return "운동 참가 멤버 백도어 세팅이 완료되었습니다.";
+    }
+
+    private void setupFullMembersPosts() {
+
+    }
+
+    private void setupOnePost() {
+        jdbcTemplate.update(
+            "insert into POSTS(" +
+                "ID, USER_ID, HITS, CREATED_AT, UPDATED_AT, DETAIL) " +
+                "values(?, ?, ?, ?, ?, ?)",
+            1L, 1L, 123L, LocalDateTime.now(), LocalDateTime.now(),
+            "야구 인원 모집 게시글입니다."
+        );
+        jdbcTemplate.update(
+            "insert into USERS(" +
+                "ID, IDENTIFIER, PASSWORD, NAME, GENDER, PHONE_NUMBER) " +
+                "values(?, ?, ?, ?, ?, ?)",
+            1L, "identifier1", "Password!1", "작성자 이름", "남성", "010-0000-0001"
+        );
+        jdbcTemplate.update(
+            "insert into REGISTERS(" +
+                "ID, USER_ID, GAME_ID, STATUS) " +
+                "values(?, ?, ?, ?)",
+            1L, 1L, 1L, RegisterStatus.ACCEPTED
+        );
+        jdbcTemplate.update(
+            "insert into GAMES(" +
+                "ID, POST_ID, EXERCISE_NAME, DATE, PLACE_NAME, TARGET_MEMBER_COUNT) " +
+                "values(?, ?, ?, ?, ?, ?)",
+            1L, 1L, "배드민턴", "2022년 11월 13일 14:00~17:00", "올림픽공원", 4
+        );
+    }
+
+    @GetMapping("setup-members-not-finished")
+    public String setupMembersNotFinished() {
+        resetDatabase();
+        setupOnePost();
+
+        setUpUsers(2, 5);
+
+        jdbcTemplate.update(
+            "insert into REGISTERS(" +
+                "ID, USER_ID, GAME_ID, STATUS) " +
+                "values(?, ?, ?, ?)",
+            2L, 2L, 1L, RegisterStatus.ACCEPTED
+        );
+        jdbcTemplate.update(
+            "insert into REGISTERS(" +
+                "ID, USER_ID, GAME_ID, STATUS) " +
+                "values(?, ?, ?, ?)",
+            3L, 3L, 1L, RegisterStatus.CANCELED
+        );
+        jdbcTemplate.update(
+            "insert into REGISTERS(" +
+                "ID, USER_ID, GAME_ID, STATUS) " +
+                "values(?, ?, ?, ?)",
+            4L, 4L, 1L, RegisterStatus.PROCESSING
+        );
+
+        return "운동 게시글 1개 참가자 목록 (잔여석 있음) 백도어 세팅이 완료되었습니다.";
+    }
+
+    @GetMapping("setup-members-finished")
+    public String setupMembersFinished() {
+        resetDatabase();
+        setupOnePost();
+
+        setUpUsers(2, 5);
+
         jdbcTemplate.update(
             "insert into REGISTERS(" +
                 "ID, USER_ID, GAME_ID, STATUS) " +
@@ -82,66 +234,102 @@ public class BackdoorController {
             "insert into REGISTERS(" +
                 "ID, USER_ID, GAME_ID, STATUS) " +
                 "values(?, ?, ?, ?)",
-            4L, 4L, 2L, RegisterStatus.ACCEPTED
-        );
-
-        jdbcTemplate.update(
-            "insert into USERS(" +
-                "ID, NAME, GENDER) " +
-                "values(?, ?, ?)",
-            1L, "사용자 1", "남성"
-        );
-        jdbcTemplate.update(
-            "insert into USERS(" +
-                "ID, NAME, GENDER) " +
-                "values(?, ?, ?)",
-            2L, "사용자 2", "남성"
-        );
-        jdbcTemplate.update(
-            "insert into USERS(" +
-                "ID, NAME, GENDER) " +
-                "values(?, ?, ?)",
-            3L, "사용자 3", "남성"
-        );
-        jdbcTemplate.update(
-            "insert into USERS(" +
-                "ID, NAME, GENDER) " +
-                "values(?, ?, ?)",
-            4L, "사용자 4", "여성"
-        );
-
-        return "게시물 목록 조회 백도어 세팅이 완료되었습니다.";
-    }
-
-    private void resetDatabaseForPosts() {
-        jdbcTemplate.execute("delete from POSTS");
-        jdbcTemplate.execute("delete from GAMES");
-        jdbcTemplate.execute("delete from REGISTERS");
-        jdbcTemplate.execute("delete from USERS");
-    }
-
-    @GetMapping("clear-members")
-    public String emptyMembers() {
-        jdbcTemplate.execute("delete from REGISTERS");
-
-        return "운동 참가 멤버 비우기 백도어 세팅이 완료되었습니다.";
-    }
-
-    @GetMapping("setup-members")
-    public String setupMembers() {
-        jdbcTemplate.update(
-            "insert into REGISTERS(" +
-                "ID, USER_ID, GAME_ID, STATUS) " +
-                "values(?, ?, ?, ?)",
-            1L, 1L, 1L, RegisterStatus.ACCEPTED
+            4L, 4L, 1L, RegisterStatus.ACCEPTED
         );
         jdbcTemplate.update(
             "insert into REGISTERS(" +
                 "ID, USER_ID, GAME_ID, STATUS) " +
                 "values(?, ?, ?, ?)",
-            2L, 1L, 2L, RegisterStatus.ACCEPTED
+            5L, 5L, 1L, RegisterStatus.PROCESSING
         );
 
-        return "운동 참가 멤버 백도어 세팅이 완료되었습니다.";
+        return "운동 게시글 1개 참가자 목록 (잔여석 있음) 백도어 세팅이 완료되었습니다.";
+    }
+
+    @GetMapping("setup-members-registered")
+    public String setupMembersRegistered() {
+        resetDatabase();
+        setupOnePost();
+
+        setUpUsers(2, 4);
+
+        jdbcTemplate.update(
+            "insert into REGISTERS(" +
+                "ID, USER_ID, GAME_ID, STATUS) " +
+                "values(?, ?, ?, ?)",
+            2L, 2L, 1L, RegisterStatus.PROCESSING
+        );
+        jdbcTemplate.update(
+            "insert into REGISTERS(" +
+                "ID, USER_ID, GAME_ID, STATUS) " +
+                "values(?, ?, ?, ?)",
+            3L, 3L, 1L, RegisterStatus.ACCEPTED
+        );
+        jdbcTemplate.update(
+            "insert into REGISTERS(" +
+                "ID, USER_ID, GAME_ID, STATUS) " +
+                "values(?, ?, ?, ?)",
+            4L, 4L, 1L, RegisterStatus.ACCEPTED
+        );
+
+        return "운동 게시글 1개 참가자 목록 (사용자가 신청) 백도어 세팅이 완료되었습니다.";
+    }
+
+    @GetMapping("setup-members-with-applicants")
+    public String setupMembersWithApplicants() {
+        resetDatabase();
+        setupOnePost();
+
+        setUpUsers(2, 4);
+
+        jdbcTemplate.update(
+            "insert into REGISTERS(" +
+                "ID, USER_ID, GAME_ID, STATUS) " +
+                "values(?, ?, ?, ?)",
+            2L, 2L, 1L, RegisterStatus.PROCESSING
+        );
+        jdbcTemplate.update(
+            "insert into REGISTERS(" +
+                "ID, USER_ID, GAME_ID, STATUS) " +
+                "values(?, ?, ?, ?)",
+            3L, 3L, 1L, RegisterStatus.PROCESSING
+        );
+        jdbcTemplate.update(
+            "insert into REGISTERS(" +
+                "ID, USER_ID, GAME_ID, STATUS) " +
+                "values(?, ?, ?, ?)",
+            4L, 4L, 1L, RegisterStatus.PROCESSING
+        );
+
+        return "운동 게시글 1개 신청자 목록 (참가신청 있음) 백도어 세팅이 완료되었습니다.";
+    }
+
+    @GetMapping("setup-members-without-applicants")
+    public String setupMembersWithoutApplicants() {
+        resetDatabase();
+        setupOnePost();
+
+        setUpUsers(2, 4);
+
+        jdbcTemplate.update(
+            "insert into REGISTERS(" +
+                "ID, USER_ID, GAME_ID, STATUS) " +
+                "values(?, ?, ?, ?)",
+            2L, 2L, 1L, RegisterStatus.CANCELED
+        );
+        jdbcTemplate.update(
+            "insert into REGISTERS(" +
+                "ID, USER_ID, GAME_ID, STATUS) " +
+                "values(?, ?, ?, ?)",
+            3L, 3L, 1L, RegisterStatus.REJECTED
+        );
+        jdbcTemplate.update(
+            "insert into REGISTERS(" +
+                "ID, USER_ID, GAME_ID, STATUS) " +
+                "values(?, ?, ?, ?)",
+            4L, 4L, 1L, RegisterStatus.ACCEPTED
+        );
+
+        return "운동 게시글 1개 신청자 목록 (참가신청 없음) 백도어 세팅이 완료되었습니다.";
     }
 }

--- a/src/main/java/kr/megaptera/smash/controllers/SessionController.java
+++ b/src/main/java/kr/megaptera/smash/controllers/SessionController.java
@@ -1,11 +1,10 @@
 package kr.megaptera.smash.controllers;
 
 import com.auth0.jwt.exceptions.JWTDecodeException;
-import kr.megaptera.smash.dtos.LoginRequestDto;
 import kr.megaptera.smash.dtos.LoginFailedErrorDto;
+import kr.megaptera.smash.dtos.LoginRequestDto;
 import kr.megaptera.smash.dtos.LoginResultDto;
 import kr.megaptera.smash.exceptions.LoginFailed;
-import kr.megaptera.smash.models.User;
 import kr.megaptera.smash.services.LoginService;
 import kr.megaptera.smash.utils.JwtUtil;
 import org.springframework.http.HttpStatus;
@@ -44,14 +43,16 @@ public class SessionController {
             throw new LoginFailed(errorMessage);
         }
 
-        Long userId = loginRequestDto.getUserId();
-        User user = loginService.verifyUser(userId);
+        Long userId = loginService.verifyUser(
+            loginRequestDto.getIdentifier(),
+            loginRequestDto.getPassword()
+        );
 
         try {
-            String accessToken = jwtUtil.encode(user.id());
+            String accessToken = jwtUtil.encode(userId);
             return new LoginResultDto(accessToken);
         } catch (JWTDecodeException exception) {
-            throw new LoginFailed("user Id 인코딩 과정에서 문제가 발생했습니다. (202)");
+            throw new LoginFailed("인코딩 과정에서 문제가 발생했습니다.");
         }
     }
 

--- a/src/main/java/kr/megaptera/smash/dtos/LoginRequestDto.java
+++ b/src/main/java/kr/megaptera/smash/dtos/LoginRequestDto.java
@@ -1,20 +1,28 @@
 package kr.megaptera.smash.dtos;
 
-import javax.validation.constraints.NotNull;
+import javax.validation.constraints.NotBlank;
 
 public class LoginRequestDto {
-    @NotNull(message = "user Id를 입력해주세요. (200)")
-    private Long userId;
+    @NotBlank(message = "아이디를 입력해주세요.")
+    private String identifier;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
 
     public LoginRequestDto() {
 
     }
 
-    public LoginRequestDto(Long userId) {
-        this.userId = userId;
+    public LoginRequestDto(String identifier, String password) {
+        this.identifier = identifier;
+        this.password = password;
     }
 
-    public Long getUserId() {
-        return userId;
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public String getPassword() {
+        return password;
     }
 }

--- a/src/main/java/kr/megaptera/smash/models/User.java
+++ b/src/main/java/kr/megaptera/smash/models/User.java
@@ -16,6 +16,9 @@ public class User {
     private Long id;
 
     @Embedded
+    private UserAccount account;
+
+    @Embedded
     private UserName name;
 
     @Embedded
@@ -29,11 +32,13 @@ public class User {
     }
 
     public User(Long id,
+                UserAccount account,
                 UserName name,
                 UserGender gender,
                 UserPhoneNumber phoneNumber
     ) {
         this.id = id;
+        this.account = account;
         this.name = name;
         this.gender = gender;
         this.phoneNumber = phoneNumber;
@@ -44,6 +49,7 @@ public class User {
         for (long id = 1; id <= generationCount; id += 1) {
             User user = new User(
                 id,
+                new UserAccount("UserIdentifier" + id),
                 new UserName("사용자 " + id),
                 new UserGender("성별"),
                 new UserPhoneNumber("010-0000-0000")
@@ -55,6 +61,10 @@ public class User {
 
     public Long id() {
         return id;
+    }
+
+    public UserAccount account() {
+        return account;
     }
 
     public UserName name() {
@@ -69,9 +79,10 @@ public class User {
         return phoneNumber;
     }
 
-    public static User fake(String name) {
+    public static User fake(String name, String identifier) {
         return new User(
             1L,
+            new UserAccount(identifier),
             new UserName(name),
             new UserGender("여성"),
             new UserPhoneNumber("010-8888-8888")

--- a/src/main/java/kr/megaptera/smash/models/UserAccount.java
+++ b/src/main/java/kr/megaptera/smash/models/UserAccount.java
@@ -1,0 +1,54 @@
+package kr.megaptera.smash.models;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import java.util.Objects;
+
+@Embeddable
+public class UserAccount {
+    @Column(name = "identifier")
+    private String identifier;
+
+    @Column(name = "password")
+    private String encodedPassword;
+
+    public UserAccount() {
+
+    }
+
+    public UserAccount(String identifier) {
+        this.identifier = identifier;
+    }
+
+    public void changePassword(String password,
+                               PasswordEncoder passwordEncoder) {
+        encodedPassword = passwordEncoder.encode(password);
+    }
+
+    public boolean authenticate(String password,
+                                PasswordEncoder passwordEncoder) {
+        return passwordEncoder.matches(password, encodedPassword);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        UserAccount that = (UserAccount) o;
+        return Objects.equals(identifier, that.identifier);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(identifier);
+    }
+
+    @Override
+    public String toString() {
+        return "UserAccount{" +
+            "identifier='" + identifier + '\'' +
+            '}';
+    }
+}

--- a/src/main/java/kr/megaptera/smash/repositories/UserRepository.java
+++ b/src/main/java/kr/megaptera/smash/repositories/UserRepository.java
@@ -3,6 +3,8 @@ package kr.megaptera.smash.repositories;
 import kr.megaptera.smash.models.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+import java.util.Optional;
 
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByAccountIdentifier(String identifier);
 }

--- a/src/test/java/kr/megaptera/smash/controllers/BackdoorControllerTest.java
+++ b/src/test/java/kr/megaptera/smash/controllers/BackdoorControllerTest.java
@@ -29,14 +29,43 @@ class BackdoorControllerTest {
     }
 
     @Test
-    void clearMembers() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.get("/backdoor/clear-members"))
+    void setupMembersPosts() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/backdoor/setup-members-posts"))
             .andExpect(MockMvcResultMatchers.status().isOk());
     }
 
     @Test
-    void setupMembers() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.get("/backdoor/setup-members"))
+    void setupMembersNotFinished() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders
+                .get("/backdoor/setup-members-not-finished"))
+            .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @Test
+    void setupMembersFinished() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders
+                .get("/backdoor/setup-members-finished"))
+            .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @Test
+    void setupMembersRegistered() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders
+                .get("/backdoor/setup-members-registered"))
+            .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @Test
+    void setupMembersWithApplicants() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders
+                .get("/backdoor/setup-members-with-applicants"))
+            .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @Test
+    void setupMembersWithoutApplicants() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders
+                .get("/backdoor/setup-members-without-applicants"))
             .andExpect(MockMvcResultMatchers.status().isOk());
     }
 }

--- a/src/test/java/kr/megaptera/smash/controllers/GameControllerTest.java
+++ b/src/test/java/kr/megaptera/smash/controllers/GameControllerTest.java
@@ -1,9 +1,9 @@
 package kr.megaptera.smash.controllers;
 
+import kr.megaptera.smash.config.MockMvcEncoding;
 import kr.megaptera.smash.dtos.GameDetailDto;
 import kr.megaptera.smash.models.Game;
 import kr.megaptera.smash.models.Register;
-import kr.megaptera.smash.models.RegisterStatus;
 import kr.megaptera.smash.services.GetGameService;
 import kr.megaptera.smash.utils.JwtUtil;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,6 +21,7 @@ import java.util.List;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.BDDMockito.given;
 
+@MockMvcEncoding
 @WebMvcTest(GameController.class)
 class GameControllerTest {
     @Autowired

--- a/src/test/java/kr/megaptera/smash/controllers/HomeControllerTest.java
+++ b/src/test/java/kr/megaptera/smash/controllers/HomeControllerTest.java
@@ -1,5 +1,6 @@
 package kr.megaptera.smash.controllers;
 
+import kr.megaptera.smash.config.MockMvcEncoding;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -9,6 +10,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import static org.hamcrest.Matchers.containsString;
 
+@MockMvcEncoding
 @WebMvcTest(HomeController.class)
 class HomeControllerTest {
   @Autowired

--- a/src/test/java/kr/megaptera/smash/controllers/PostControllerTest.java
+++ b/src/test/java/kr/megaptera/smash/controllers/PostControllerTest.java
@@ -1,5 +1,6 @@
 package kr.megaptera.smash.controllers;
 
+import kr.megaptera.smash.config.MockMvcEncoding;
 import kr.megaptera.smash.dtos.GameInPostListDto;
 import kr.megaptera.smash.dtos.PostDetailDto;
 import kr.megaptera.smash.dtos.PostListDto;
@@ -28,6 +29,7 @@ import java.util.List;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.BDDMockito.given;
 
+@MockMvcEncoding
 @WebMvcTest(PostController.class)
 class PostControllerTest {
     @Autowired
@@ -113,7 +115,7 @@ class PostControllerTest {
 
         // post
         Post post = Post.fake("주말 오전 테니스 같이하실 여성분들 찾습니다.");
-        User user = User.fake("The Prince of the Tennis");
+        User user = User.fake("The Prince of the Tennis", "PrinceOfTennis1234");
         postDetailDto = new PostDetailDto(
             post.id(),
             post.hits().value(),

--- a/src/test/java/kr/megaptera/smash/controllers/RegisterControllerTest.java
+++ b/src/test/java/kr/megaptera/smash/controllers/RegisterControllerTest.java
@@ -1,5 +1,6 @@
 package kr.megaptera.smash.controllers;
 
+import kr.megaptera.smash.config.MockMvcEncoding;
 import kr.megaptera.smash.dtos.ApplicantDetailDto;
 import kr.megaptera.smash.dtos.ApplicantsDetailDto;
 import kr.megaptera.smash.dtos.MemberDetailDto;
@@ -31,6 +32,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
+@MockMvcEncoding
 @WebMvcTest(RegisterController.class)
 class RegisterControllerTest {
     @Autowired

--- a/src/test/java/kr/megaptera/smash/services/GetPostServiceTest.java
+++ b/src/test/java/kr/megaptera/smash/services/GetPostServiceTest.java
@@ -5,6 +5,7 @@ import kr.megaptera.smash.models.Post;
 import kr.megaptera.smash.models.PostDetail;
 import kr.megaptera.smash.models.PostHits;
 import kr.megaptera.smash.models.User;
+import kr.megaptera.smash.models.UserAccount;
 import kr.megaptera.smash.models.UserGender;
 import kr.megaptera.smash.models.UserName;
 import kr.megaptera.smash.models.UserPhoneNumber;
@@ -48,6 +49,7 @@ class GetPostServiceTest {
         );
         User user = new User(
             userId,
+            new UserAccount("BowlingGirl32"),
             new UserName("볼링맨"),
             new UserGender("남성"),
             new UserPhoneNumber("010-8888-8888")

--- a/src/test/java/kr/megaptera/smash/services/GetProcessingRegisterServiceTest.java
+++ b/src/test/java/kr/megaptera/smash/services/GetProcessingRegisterServiceTest.java
@@ -5,6 +5,7 @@ import kr.megaptera.smash.dtos.ApplicantsDetailDto;
 import kr.megaptera.smash.models.Register;
 import kr.megaptera.smash.models.RegisterStatus;
 import kr.megaptera.smash.models.User;
+import kr.megaptera.smash.models.UserAccount;
 import kr.megaptera.smash.models.UserGender;
 import kr.megaptera.smash.models.UserName;
 import kr.megaptera.smash.models.UserPhoneNumber;
@@ -67,12 +68,14 @@ class GetProcessingRegisterServiceTest {
         users = List.of(
             new User(
                 1L,
+                new UserAccount("hsjkdss228"),
                 new UserName("사용자 이름 1"),
                 new UserGender("남성"),
                 new UserPhoneNumber("010-1234-5678")
             ),
             new User(
                 2L,
+                new UserAccount("dhkddlsgn228"),
                 new UserName("사용자 이름 2"),
                 new UserGender("여성"),
                 new UserPhoneNumber("010-2345-6789")

--- a/src/test/java/kr/megaptera/smash/services/PostRegisterGameServiceTest.java
+++ b/src/test/java/kr/megaptera/smash/services/PostRegisterGameServiceTest.java
@@ -10,6 +10,7 @@ import kr.megaptera.smash.models.Register;
 import kr.megaptera.smash.models.Place;
 import kr.megaptera.smash.models.RegisterStatus;
 import kr.megaptera.smash.models.User;
+import kr.megaptera.smash.models.UserAccount;
 import kr.megaptera.smash.models.UserGender;
 import kr.megaptera.smash.models.UserName;
 import kr.megaptera.smash.models.UserPhoneNumber;
@@ -80,6 +81,7 @@ class PostRegisterGameServiceTest {
         Long userId = 1L;
         User user = new User(
             userId,
+            new UserAccount("MinjiRungRung12"),
             new UserName("사용자명"),
             new UserGender("남성"),
             new UserPhoneNumber("010-2222-2222")


### PR DESCRIPTION
- UserAccount 객체 생성
  - 값 객체로 identifier, encodedPassword를 가지고 있음
  - 시그니처 불일치 에러를 먼저 잡고, 테스트 코드를 보완
  - UserId를 fake로 생성할 때 identifier도 받도록 함

- User Id를 인코딩하던 방식에서 Identifier를 인코딩하도록 구조 변경
  - JwtUtil에서 인코딩할 대상을 Identifier로 변경
  - Interceptor에서 디코딩한 Identifier로 User Id를 찾는 로직이 추가되어야 함
  - LoginDto에서는 이제 예외처리가 추가되어야 함
  - User 모델에 Identifier, Password 필드 추가, PasswordEncoder 사용 로직 추가

- 일단 백엔드에서 처리하는 예외는 모두 동일한 LoginFailed에 다른 종류의 메시지를 담아 전달하는 것으로 처리
- 예외 코드를 추가해서 Map으로 보내야 할지는 고민 (그렇게 복잡하게 처리해주지 않아도 될 것 같음)

예상 뽀모 7
실제 뽀모 9 (프론트엔드, 백엔드 통합)