### PR TITLE
운동 시간 데이터 생성 로직을 프론트엔드가 아닌 서버에서 수행

### DIFF
--- a/src/main/java/kr/megaptera/smash/controllers/PostController.java
+++ b/src/main/java/kr/megaptera/smash/controllers/PostController.java
@@ -34,13 +34,17 @@ import java.util.stream.Collectors;
 public class PostController {
     private static final Integer BLANK_GAME_EXERCISE = 100;
     private static final Integer BLANK_GAME_DATE = 101;
-    private static final Integer BLANK_GAME_TIME = 102;
-    private static final Integer NOT_FILLED_GAME_TIME = 103;
-    private static final Integer BLANK_GAME_PLACE = 104;
-    private static final Integer NULL_GAME_TARGET_MEMBER_COUNT = 105;
-    private static final Integer BLANK_POST_DETAIL = 106;
-    private static final Integer USER_NOT_FOUND = 107;
-    private static final Integer DEFAULT_ERROR = 108;
+    private static final Integer BLANK_GAME_START_AM_PM = 102;
+    private static final Integer BLANK_GAME_START_HOUR = 103;
+    private static final Integer BLANK_GAME_START_MINUTE = 104;
+    private static final Integer BLANK_GAME_END_AM_PM = 105;
+    private static final Integer BLANK_GAME_END_HOUR = 106;
+    private static final Integer BLANK_GAME_END_MINUTE = 107;
+    private static final Integer BLANK_GAME_PLACE = 108;
+    private static final Integer NULL_GAME_TARGET_MEMBER_COUNT = 109;
+    private static final Integer BLANK_POST_DETAIL = 110;
+    private static final Integer USER_NOT_FOUND = 111;
+    private static final Integer DEFAULT_ERROR = 112;
 
     private final GetPostsService getPostsService;
     private final GetPostService getPostService;
@@ -90,7 +94,12 @@ public class PostController {
             accessedUserId,
             postAndGameRequestDto.getGameExercise(),
             postAndGameRequestDto.getGameDate(),
-            postAndGameRequestDto.getGameTime(),
+            postAndGameRequestDto.getGameStartTimeAmPm(),
+            postAndGameRequestDto.getGameStartHour(),
+            postAndGameRequestDto.getGameStartMinute(),
+            postAndGameRequestDto.getGameEndTimeAmPm(),
+            postAndGameRequestDto.getGameEndHour(),
+            postAndGameRequestDto.getGameEndMinute(),
             postAndGameRequestDto.getGamePlace(),
             postAndGameRequestDto.getGameTargetMemberCount(),
             postAndGameRequestDto.getPostDetail()
@@ -123,8 +132,12 @@ public class PostController {
         return switch (errorMessage) {
             case "운동을 입력해주세요." -> BLANK_GAME_EXERCISE;
             case "운동 날짜를 입력해주세요." -> BLANK_GAME_DATE;
-            case "운동 시간을 입력해주세요." -> BLANK_GAME_TIME;
-            case "입력하지 않은 운동 시간이 있습니다." -> NOT_FILLED_GAME_TIME;
+            case "시작시간 오전/오후 구분을 입력해주세요." -> BLANK_GAME_START_AM_PM;
+            case "시작 시간을 입력해주세요." -> BLANK_GAME_START_HOUR;
+            case "시작 분을 입력해주세요." -> BLANK_GAME_START_MINUTE;
+            case "종료시간 오전/오후 구분을 입력해주세요." -> BLANK_GAME_END_AM_PM;
+            case "종료 시간을 입력해주세요." -> BLANK_GAME_END_HOUR;
+            case "종료 분을 입력해주세요." -> BLANK_GAME_END_MINUTE;
             case "운동 장소 이름을 입력해주세요." -> BLANK_GAME_PLACE;
             case "사용자 수를 입력해주세요." -> NULL_GAME_TARGET_MEMBER_COUNT;
             case "게시물 상세 내용을 입력해주세요." -> BLANK_POST_DETAIL;

--- a/src/main/java/kr/megaptera/smash/dtos/PostAndGameRequestDto.java
+++ b/src/main/java/kr/megaptera/smash/dtos/PostAndGameRequestDto.java
@@ -1,11 +1,9 @@
 package kr.megaptera.smash.dtos;
 
 import kr.megaptera.smash.validations.NotBlankGroup;
-import kr.megaptera.smash.validations.PatternMatchGroup;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
 
 public class PostAndGameRequestDto {
     @NotBlank(
@@ -20,12 +18,33 @@ public class PostAndGameRequestDto {
 
     @NotBlank(
         groups = NotBlankGroup.class,
-        message = "운동 시간을 입력해주세요.")
-    @Pattern(
-        groups = PatternMatchGroup.class,
-        regexp = "^(?=.*\\d)\\d{1,2},\\d{1,2},\\d{1,2},\\d{1,2}$",
-        message = "입력하지 않은 운동 시간이 있습니다.")
-    private String gameTime;
+        message = "시작시간 오전/오후 구분을 입력해주세요.")
+    private String gameStartTimeAmPm;
+
+    @NotBlank(
+        groups = NotBlankGroup.class,
+        message = "시작 시간을 입력해주세요.")
+    private String gameStartHour;
+
+    @NotBlank(
+        groups = NotBlankGroup.class,
+        message = "시작 분을 입력해주세요.")
+    private String gameStartMinute;
+
+    @NotBlank(
+        groups = NotBlankGroup.class,
+        message = "종료시간 오전/오후 구분을 입력해주세요.")
+    private String gameEndTimeAmPm;
+
+    @NotBlank(
+        groups = NotBlankGroup.class,
+        message = "종료 시간을 입력해주세요.")
+    private String gameEndHour;
+
+    @NotBlank(
+        groups = NotBlankGroup.class,
+        message = "종료 분을 입력해주세요.")
+    private String gameEndMinute;
 
     @NotBlank(
         groups = NotBlankGroup.class,
@@ -48,13 +67,24 @@ public class PostAndGameRequestDto {
 
     public PostAndGameRequestDto(String gameExercise,
                                  String gameDate,
-                                 String gameTime,
+                                 String gameStartTimeAmPm,
+                                 String gameStartHour,
+                                 String gameStartMinute,
+                                 String gameEndTimeAmPm,
+                                 String gameEndHour,
+                                 String gameEndMinute,
                                  String gamePlace,
                                  Integer gameTargetMemberCount,
-                                 String postDetail) {
+                                 String postDetail
+    ) {
         this.gameExercise = gameExercise;
         this.gameDate = gameDate;
-        this.gameTime = gameTime;
+        this.gameStartTimeAmPm = gameStartTimeAmPm;
+        this.gameStartHour = gameStartHour;
+        this.gameStartMinute = gameStartMinute;
+        this.gameEndTimeAmPm = gameEndTimeAmPm;
+        this.gameEndHour = gameEndHour;
+        this.gameEndMinute = gameEndMinute;
         this.gamePlace = gamePlace;
         this.gameTargetMemberCount = gameTargetMemberCount;
         this.postDetail = postDetail;
@@ -68,8 +98,28 @@ public class PostAndGameRequestDto {
         return gameDate;
     }
 
-    public String getGameTime() {
-        return gameTime;
+    public String getGameStartTimeAmPm() {
+        return gameStartTimeAmPm;
+    }
+
+    public String getGameStartHour() {
+        return gameStartHour;
+    }
+
+    public String getGameStartMinute() {
+        return gameStartMinute;
+    }
+
+    public String getGameEndTimeAmPm() {
+        return gameEndTimeAmPm;
+    }
+
+    public String getGameEndHour() {
+        return gameEndHour;
+    }
+
+    public String getGameEndMinute() {
+        return gameEndMinute;
     }
 
     public String getGamePlace() {

--- a/src/main/java/kr/megaptera/smash/models/GameDateTime.java
+++ b/src/main/java/kr/megaptera/smash/models/GameDateTime.java
@@ -42,18 +42,45 @@ public class GameDateTime {
     }
 
     public String joinDateAndTime() {
-        String startHour = formatTime(startTime.getHour());
+        String startTimeAmPm = calculateAmPm(startTime.getHour());
+        String endTimeAmPm = calculateAmPm(endTime.getHour());
+
+        int startHour = convertHourStyle(startTime.getHour(), startTimeAmPm);
+        String formattedStartHour = formatTime(startHour);
+
+        int endHour = convertHourStyle(endTime.getHour(), endTimeAmPm);
+        String formattedEndHour = formatTime(endHour);
+
         String startMinute = formatTime(startTime.getMinute());
-        String endHour = formatTime(endTime.getHour());
         String endMinute = formatTime(endTime.getMinute());
 
         return date.getYear() + "년 "
             + date.getMonthValue() + "월 "
             + date.getDayOfMonth() + "일 "
-            + startHour + ":"
-            + startMinute + "~"
-            + endHour + ":"
+            + startTimeAmPm + " "
+            + formattedStartHour + ":"
+            + startMinute + " ~ "
+            + endTimeAmPm + " "
+            + formattedEndHour + ":"
             + endMinute;
+    }
+
+    private String calculateAmPm(int hour) {
+        return hour < 12
+            ? "오전"
+            : "오후";
+    }
+
+    private int convertHourStyle(int hour, String timeAmPm) {
+        if (hour == 0 && timeAmPm.equals("오전")) {
+            return 12;
+        }
+
+        if (hour > 12 && timeAmPm.equals("오후")) {
+            return hour - 12;
+        }
+
+        return hour;
     }
 
     private String formatTime(int time) {

--- a/src/main/java/kr/megaptera/smash/services/CreatePostService.java
+++ b/src/main/java/kr/megaptera/smash/services/CreatePostService.java
@@ -40,7 +40,12 @@ public class CreatePostService {
         Long accessedUserId,
         String gameExercise,
         String gameDate,
-        String gameTime,
+        String gameStartTimeAmPm,
+        String gameStartHour,
+        String gameStartMinute,
+        String gameEndTimeAmPm,
+        String gameEndHour,
+        String gameEndMinute,
         String gamePlace,
         Integer gameTargetMemberCount,
         String postDetail
@@ -58,7 +63,12 @@ public class CreatePostService {
 
         GameDateTime gameDateTime = createGameDateTime(
             gameDate,
-            gameTime
+            gameStartTimeAmPm,
+            gameStartHour,
+            gameStartMinute,
+            gameEndTimeAmPm,
+            gameEndHour,
+            gameEndMinute
         );
 
         Game game = new Game(
@@ -74,17 +84,28 @@ public class CreatePostService {
     }
 
     public GameDateTime createGameDateTime(String gameDate,
-                                            String gameTime) {
+                                           String gameStartTimeAmPm,
+                                           String gameStartHour,
+                                           String gameStartMinute,
+                                           String gameEndTimeAmPm,
+                                           String gameEndHour,
+                                           String gameEndMinute
+    ) {
         String[] yearMonthDay = gameDate.split("-");
         int year = parseDateType(yearMonthDay[0]);
         int month = parseDateType(yearMonthDay[1]);
         int day = parseDateType(yearMonthDay[2].split("T")[0]);
 
-        String[] startAndEndHourMinute = gameTime.split(",");
-        int startHour = Integer.parseInt(startAndEndHourMinute[0]);
-        int startMinute = Integer.parseInt(startAndEndHourMinute[1]);
-        int endHour = Integer.parseInt(startAndEndHourMinute[2]);
-        int endMinute = Integer.parseInt(startAndEndHourMinute[3]);
+        int startHour = calculateHour(
+            Integer.parseInt(gameStartHour),
+            gameStartTimeAmPm
+        );
+        int endHour = calculateHour(
+            Integer.parseInt(gameEndHour),
+            gameEndTimeAmPm
+        );
+        int startMinute = Integer.parseInt(gameStartMinute);
+        int endMinute = Integer.parseInt(gameEndMinute);
 
         return new GameDateTime(
             LocalDate.of(year, month, day),
@@ -95,5 +116,16 @@ public class CreatePostService {
 
     public int parseDateType(String dateType) {
         return Integer.parseInt(dateType);
+    }
+
+    public int calculateHour(int hour,
+                             String timeAmPm) {
+        if (hour == 12 && timeAmPm.equals("am")) {
+            return 0;
+        }
+        if (hour < 12 && timeAmPm.equals("pm")) {
+            return hour + 12;
+        }
+        return hour;
     }
 }

--- a/src/test/java/kr/megaptera/smash/controllers/PostControllerTest.java
+++ b/src/test/java/kr/megaptera/smash/controllers/PostControllerTest.java
@@ -143,7 +143,7 @@ class PostControllerTest {
         postAndGameRequestDto = new PostAndGameRequestDto(
             "운동 이름",
             "2022-11-25T00:00:00.000Z",
-            "09,00,12,50",
+            "am", "09", "00", "pm", "12", "50",
             "운동 장소",
             gameTargetMemberCount,
             "게시물 상세 내용"
@@ -206,7 +206,12 @@ class PostControllerTest {
         Long userId,
         String gameExercise,
         String gameDate,
-        String gameTime,
+        String gameStartTimeAmPm,
+        String gameStartHour,
+        String gameStartMinute,
+        String gameEndTimeAmPm,
+        String gameEndHour,
+        String gameEndMinute,
         String gamePlace,
         Integer gameTargetMemberCount,
         String postDetail
@@ -215,7 +220,12 @@ class PostControllerTest {
             userId,
             gameExercise,
             gameDate,
-            gameTime,
+            gameStartTimeAmPm,
+            gameStartHour,
+            gameStartMinute,
+            gameEndTimeAmPm,
+            gameEndHour,
+            gameEndMinute,
             gamePlace,
             gameTargetMemberCount,
             postDetail
@@ -228,7 +238,12 @@ class PostControllerTest {
                 .content("{" +
                     "\"gameExercise\":\"" + gameExercise + "\"," +
                     "\"gameDate\":\"" + gameDate + "\"," +
-                    "\"gameTime\":\"" + gameTime + "\"," +
+                    "\"gameStartTimeAmPm\":\"" + gameStartTimeAmPm + "\"," +
+                    "\"gameStartHour\":\"" + gameStartHour + "\"," +
+                    "\"gameStartMinute\":\"" + gameStartMinute + "\"," +
+                    "\"gameEndTimeAmPm\":\"" + gameEndTimeAmPm + "\"," +
+                    "\"gameEndHour\":\"" + gameEndHour + "\"," +
+                    "\"gameEndMinute\":\"" + gameEndMinute + "\"," +
                     "\"gamePlace\":\"" + gamePlace + "\"," +
                     "\"gameTargetMemberCount\":" + gameTargetMemberCount + "," +
                     "\"postDetail\":\"" + postDetail + "\"" +
@@ -244,7 +259,12 @@ class PostControllerTest {
         Long userId,
         String gameExercise,
         String gameDate,
-        String gameTime,
+        String gameStartTimeAmPm,
+        String gameStartHour,
+        String gameStartMinute,
+        String gameEndTimeAmPm,
+        String gameEndHour,
+        String gameEndMinute,
         String gamePlace,
         Integer gameTargetMemberCount,
         String postDetail,
@@ -254,7 +274,12 @@ class PostControllerTest {
             userId,
             gameExercise,
             gameDate,
-            gameTime,
+            gameStartTimeAmPm,
+            gameStartHour,
+            gameStartMinute,
+            gameEndTimeAmPm,
+            gameEndHour,
+            gameEndMinute,
             gamePlace,
             gameTargetMemberCount,
             postDetail
@@ -267,7 +292,12 @@ class PostControllerTest {
                 .content("{" +
                     "\"gameExercise\":\"" + gameExercise + "\"," +
                     "\"gameDate\":\"" + gameDate + "\"," +
-                    "\"gameTime\":\"" + gameTime + "\"," +
+                    "\"gameStartTimeAmPm\":\"" + gameStartTimeAmPm + "\"," +
+                    "\"gameStartHour\":\"" + gameStartHour + "\"," +
+                    "\"gameStartMinute\":\"" + gameStartMinute + "\"," +
+                    "\"gameEndTimeAmPm\":\"" + gameEndTimeAmPm + "\"," +
+                    "\"gameEndHour\":\"" + gameEndHour + "\"," +
+                    "\"gameEndMinute\":\"" + gameEndMinute + "\"," +
                     "\"gamePlace\":\"" + gamePlace + "\"," +
                     "\"gameTargetMemberCount\":" + gameTargetMemberCount + "," +
                     "\"postDetail\":\"" + postDetail + "\"" +
@@ -285,7 +315,12 @@ class PostControllerTest {
             userId,
             postAndGameRequestDto.getGameExercise(),
             postAndGameRequestDto.getGameDate(),
-            postAndGameRequestDto.getGameTime(),
+            postAndGameRequestDto.getGameStartTimeAmPm(),
+            postAndGameRequestDto.getGameStartHour(),
+            postAndGameRequestDto.getGameStartMinute(),
+            postAndGameRequestDto.getGameEndTimeAmPm(),
+            postAndGameRequestDto.getGameEndHour(),
+            postAndGameRequestDto.getGameEndMinute(),
             postAndGameRequestDto.getGamePlace(),
             postAndGameRequestDto.getGameTargetMemberCount(),
             postAndGameRequestDto.getPostDetail()
@@ -300,7 +335,12 @@ class PostControllerTest {
             userId,
             blankGameExercise,
             postAndGameRequestDto.getGameDate(),
-            postAndGameRequestDto.getGameTime(),
+            postAndGameRequestDto.getGameStartTimeAmPm(),
+            postAndGameRequestDto.getGameStartHour(),
+            postAndGameRequestDto.getGameStartMinute(),
+            postAndGameRequestDto.getGameEndTimeAmPm(),
+            postAndGameRequestDto.getGameEndHour(),
+            postAndGameRequestDto.getGameEndMinute(),
             postAndGameRequestDto.getGamePlace(),
             postAndGameRequestDto.getGameTargetMemberCount(),
             postAndGameRequestDto.getPostDetail(),
@@ -316,7 +356,12 @@ class PostControllerTest {
             userId,
             postAndGameRequestDto.getGameExercise(),
             blankGameDate,
-            postAndGameRequestDto.getGameTime(),
+            postAndGameRequestDto.getGameStartTimeAmPm(),
+            postAndGameRequestDto.getGameStartHour(),
+            postAndGameRequestDto.getGameStartMinute(),
+            postAndGameRequestDto.getGameEndTimeAmPm(),
+            postAndGameRequestDto.getGameEndHour(),
+            postAndGameRequestDto.getGameEndMinute(),
             postAndGameRequestDto.getGamePlace(),
             postAndGameRequestDto.getGameTargetMemberCount(),
             postAndGameRequestDto.getPostDetail(),
@@ -325,14 +370,19 @@ class PostControllerTest {
     }
 
     @Test
-    void createPostWithBlankGameTime() throws Exception {
-        String blankGameTime = "";
-        String errorMessage = "운동 시간을 입력해주세요.";
+    void createPostWithBlankGameStartTimeAmPm() throws Exception {
+        String blankGameStartTimeAmPm = "";
+        String errorMessage = "시작시간 오전/오후 구분을 입력해주세요.";
         createPostWithError(
             userId,
             postAndGameRequestDto.getGameExercise(),
             postAndGameRequestDto.getGameDate(),
-            blankGameTime,
+            blankGameStartTimeAmPm,
+            postAndGameRequestDto.getGameStartHour(),
+            postAndGameRequestDto.getGameStartMinute(),
+            postAndGameRequestDto.getGameEndTimeAmPm(),
+            postAndGameRequestDto.getGameEndHour(),
+            postAndGameRequestDto.getGameEndMinute(),
             postAndGameRequestDto.getGamePlace(),
             postAndGameRequestDto.getGameTargetMemberCount(),
             postAndGameRequestDto.getPostDetail(),
@@ -341,14 +391,19 @@ class PostControllerTest {
     }
 
     @Test
-    void createPostWithNotFilledGameTime() throws Exception {
-        String notFilledGameTime = "08,,11,30";
-        String errorMessage = "입력하지 않은 운동 시간이 있습니다.";
+    void createPostWithBlankGameStartHour() throws Exception {
+        String blankGameStartHour = "";
+        String errorMessage = "시작 시간을 입력해주세요.";
         createPostWithError(
             userId,
             postAndGameRequestDto.getGameExercise(),
             postAndGameRequestDto.getGameDate(),
-            notFilledGameTime,
+            postAndGameRequestDto.getGameStartTimeAmPm(),
+            blankGameStartHour,
+            postAndGameRequestDto.getGameStartMinute(),
+            postAndGameRequestDto.getGameEndTimeAmPm(),
+            postAndGameRequestDto.getGameEndHour(),
+            postAndGameRequestDto.getGameEndMinute(),
             postAndGameRequestDto.getGamePlace(),
             postAndGameRequestDto.getGameTargetMemberCount(),
             postAndGameRequestDto.getPostDetail(),
@@ -364,7 +419,12 @@ class PostControllerTest {
             userId,
             postAndGameRequestDto.getGameExercise(),
             postAndGameRequestDto.getGameDate(),
-            postAndGameRequestDto.getGameTime(),
+            postAndGameRequestDto.getGameStartTimeAmPm(),
+            postAndGameRequestDto.getGameStartHour(),
+            postAndGameRequestDto.getGameStartMinute(),
+            postAndGameRequestDto.getGameEndTimeAmPm(),
+            postAndGameRequestDto.getGameEndHour(),
+            postAndGameRequestDto.getGameEndMinute(),
             blankGamePlace,
             postAndGameRequestDto.getGameTargetMemberCount(),
             postAndGameRequestDto.getPostDetail(),
@@ -380,7 +440,12 @@ class PostControllerTest {
             userId,
             postAndGameRequestDto.getGameExercise(),
             postAndGameRequestDto.getGameDate(),
-            postAndGameRequestDto.getGameTime(),
+            postAndGameRequestDto.getGameStartTimeAmPm(),
+            postAndGameRequestDto.getGameStartHour(),
+            postAndGameRequestDto.getGameStartMinute(),
+            postAndGameRequestDto.getGameEndTimeAmPm(),
+            postAndGameRequestDto.getGameEndHour(),
+            postAndGameRequestDto.getGameEndMinute(),
             postAndGameRequestDto.getGamePlace(),
             nullGameTargetMemberCount,
             postAndGameRequestDto.getPostDetail(),
@@ -396,7 +461,12 @@ class PostControllerTest {
             userId,
             postAndGameRequestDto.getGameExercise(),
             postAndGameRequestDto.getGameDate(),
-            postAndGameRequestDto.getGameTime(),
+            postAndGameRequestDto.getGameStartTimeAmPm(),
+            postAndGameRequestDto.getGameStartHour(),
+            postAndGameRequestDto.getGameStartMinute(),
+            postAndGameRequestDto.getGameEndTimeAmPm(),
+            postAndGameRequestDto.getGameEndHour(),
+            postAndGameRequestDto.getGameEndMinute(),
             postAndGameRequestDto.getGamePlace(),
             postAndGameRequestDto.getGameTargetMemberCount(),
             blankPostDetail,
@@ -411,7 +481,12 @@ class PostControllerTest {
             userId,
             postAndGameRequestDto.getGameExercise(),
             postAndGameRequestDto.getGameDate(),
-            postAndGameRequestDto.getGameTime(),
+            postAndGameRequestDto.getGameStartTimeAmPm(),
+            postAndGameRequestDto.getGameStartHour(),
+            postAndGameRequestDto.getGameStartMinute(),
+            postAndGameRequestDto.getGameEndTimeAmPm(),
+            postAndGameRequestDto.getGameEndHour(),
+            postAndGameRequestDto.getGameEndMinute(),
             postAndGameRequestDto.getGamePlace(),
             postAndGameRequestDto.getGameTargetMemberCount(),
             postAndGameRequestDto.getPostDetail(),

--- a/src/test/java/kr/megaptera/smash/models/GameDateTimeTest.java
+++ b/src/test/java/kr/megaptera/smash/models/GameDateTimeTest.java
@@ -21,6 +21,38 @@ class GameDateTimeTest {
 
         String dateAndTime = gameDateTime.joinDateAndTime();
         assertThat(dateAndTime)
-            .isEqualTo("2022년 12월 22일 09:00~11:55");
+            .isEqualTo("2022년 12월 22일 오전 09:00 ~ 오전 11:55");
+    }
+
+    @Test
+    void joinDateAndTimeConvertWithMidnightAndNoon() {
+        LocalDate date = LocalDate.of(2022, 12, 22);
+        LocalTime startTime = LocalTime.of(0, 0);
+        LocalTime endTime = LocalTime.of(12, 0);
+        GameDateTime gameDateTime = new GameDateTime(
+            date,
+            startTime,
+            endTime
+        );
+
+        String dateAndTime = gameDateTime.joinDateAndTime();
+        assertThat(dateAndTime)
+            .isEqualTo("2022년 12월 22일 오전 12:00 ~ 오후 12:00");
+    }
+
+    @Test
+    void joinDateAndTimeConvertWithPm() {
+        LocalDate date = LocalDate.of(2022, 12, 22);
+        LocalTime startTime = LocalTime.of(15, 30);
+        LocalTime endTime = LocalTime.of(21, 0);
+        GameDateTime gameDateTime = new GameDateTime(
+            date,
+            startTime,
+            endTime
+        );
+
+        String dateAndTime = gameDateTime.joinDateAndTime();
+        assertThat(dateAndTime)
+            .isEqualTo("2022년 12월 22일 오후 03:30 ~ 오후 09:00");
     }
 }

--- a/src/test/java/kr/megaptera/smash/services/CreatePostServiceTest.java
+++ b/src/test/java/kr/megaptera/smash/services/CreatePostServiceTest.java
@@ -62,7 +62,7 @@ class CreatePostServiceTest {
         postAndGameRequestDto = new PostAndGameRequestDto(
             "운동 이름",
             "2022-12-22T00:00:00.000Z",
-            "09,00,12,50",
+            "am", "11", "30", "pm", "04", "00",
             "운동 장소",
             gameTargetMemberCount,
             "게시물 상세 내용"
@@ -126,7 +126,12 @@ class CreatePostServiceTest {
             user.id(),
             postAndGameRequestDto.getGameExercise(),
             postAndGameRequestDto.getGameDate(),
-            postAndGameRequestDto.getGameTime(),
+            postAndGameRequestDto.getGameStartTimeAmPm(),
+            postAndGameRequestDto.getGameStartHour(),
+            postAndGameRequestDto.getGameStartMinute(),
+            postAndGameRequestDto.getGameEndTimeAmPm(),
+            postAndGameRequestDto.getGameEndHour(),
+            postAndGameRequestDto.getGameEndMinute(),
             postAndGameRequestDto.getGamePlace(),
             postAndGameRequestDto.getGameTargetMemberCount(),
             postAndGameRequestDto.getPostDetail()
@@ -144,11 +149,21 @@ class CreatePostServiceTest {
     @Test
     void createGameDateTime() {
         String gameDate = "2022-4-3T00:00:00.000Z";
-        String gameTime = "07,30,11,00";
+        String gameStartTimeAmPm = "am";
+        String gameStartHour = "07";
+        String gameStartMinute = "30";
+        String gameEndTimeAmPm = "pm";
+        String gameEndHour = "11";
+        String gameEndMinute = "00";
 
         GameDateTime gameDateTime = createPostService.createGameDateTime(
             gameDate,
-            gameTime
+            gameStartTimeAmPm,
+            gameStartHour,
+            gameStartMinute,
+            gameEndTimeAmPm,
+            gameEndHour,
+            gameEndMinute
         );
 
         assertThat(gameDateTime.date())
@@ -156,7 +171,7 @@ class CreatePostServiceTest {
         assertThat(gameDateTime.startTime())
             .isEqualTo(LocalTime.of(7, 30));
         assertThat(gameDateTime.endTime())
-            .isEqualTo(LocalTime.of(11, 0));
+            .isEqualTo(LocalTime.of(23, 0));
     }
 
     @Test
@@ -169,7 +184,12 @@ class CreatePostServiceTest {
                 user.id(),
                 postAndGameRequestDto.getGameExercise(),
                 postAndGameRequestDto.getGameDate(),
-                postAndGameRequestDto.getGameTime(),
+                postAndGameRequestDto.getGameStartTimeAmPm(),
+                postAndGameRequestDto.getGameStartHour(),
+                postAndGameRequestDto.getGameStartMinute(),
+                postAndGameRequestDto.getGameEndTimeAmPm(),
+                postAndGameRequestDto.getGameEndHour(),
+                postAndGameRequestDto.getGameEndMinute(),
                 postAndGameRequestDto.getGamePlace(),
                 postAndGameRequestDto.getGameTargetMemberCount(),
                 postAndGameRequestDto.getPostDetail()


### PR DESCRIPTION
오전/오후를 선택을 안 해도 글이 생성되는 문제가 있음, 예외처리를 위해 프론트엔드에서 Error를 발생시키는 것을 시도했음
```JavaScript
if (gameStartTimeAmPm === ''
      || gameEndTimeAmPm === '') {
      throw new Error({
        errorCodeAndMessages: {
          104: '오전/오후를 선택하지 않았습니다.',
        },
      });
    }
```
백엔드 에러를 저장하는 상태에 에러를 저장하기 위해 같은 구조로 작성했지만 테스트 코드에서 에러 상태를 계속 저장하지 못함
이 구조는 아닌 것 같아 프론트엔드에서 계산을 수행하는 로직을 모두 빼고, 백엔드에서만 시간을 계산하게 함