### PR TITLE
신청 시 잔여석이 없을 경우 예외처리

### DIFF
--- a/src/main/java/kr/megaptera/smash/controllers/RegisterController.java
+++ b/src/main/java/kr/megaptera/smash/controllers/RegisterController.java
@@ -29,7 +29,8 @@ public class RegisterController {
     private static final Integer GAME_NOT_FOUND = 100;
     private static final Integer ALREADY_REGISTERED_GAME = 101;
     private static final Integer USER_NOT_FOUND = 102;
-    private static final Integer DEFAULT = 103;
+    private static final Integer FULLY_PARTICIPANTS = 103;
+    private static final Integer DEFAULT = 104;
 
     private final GetAcceptedRegisterService getAcceptedRegisterService;
     private final GetProcessingRegisterService getProcessingRegisterService;
@@ -99,7 +100,12 @@ public class RegisterController {
         String errorMessage = errorCode.equals(DEFAULT)
             ? "알 수 없는 에러입니다."
             : exception.getMessage();
-        return new RegisterGameFailedErrorDto(errorCode, errorMessage);
+
+        return new RegisterGameFailedErrorDto(
+            errorCode,
+            errorMessage,
+            exception.getGameId()
+        );
     }
 
     private Integer setCodeFromMessage(String errorMessage) {
@@ -107,6 +113,7 @@ public class RegisterController {
             case "주어진 게임 번호에 해당하는 게임을 찾을 수 없습니다." -> GAME_NOT_FOUND;
             case "이미 신청이 완료된 운동입니다." -> ALREADY_REGISTERED_GAME;
             case "주어진 사용자 번호에 해당하는 사용자를 찾을 수 없습니다." -> USER_NOT_FOUND;
+            case "참가 정원이 모두 차 참가를 신청할 수 없습니다." -> FULLY_PARTICIPANTS;
             default -> DEFAULT;
         };
     }

--- a/src/main/java/kr/megaptera/smash/dtos/RegisterGameFailedErrorDto.java
+++ b/src/main/java/kr/megaptera/smash/dtos/RegisterGameFailedErrorDto.java
@@ -5,9 +5,14 @@ public class RegisterGameFailedErrorDto {
 
     private final String errorMessage;
 
-    public RegisterGameFailedErrorDto(Integer errorCode, String errorMessage) {
+    private final Long gameId;
+
+    public RegisterGameFailedErrorDto(Integer errorCode,
+                                      String errorMessage,
+                                      Long gameId) {
         this.errorCode = errorCode;
         this.errorMessage = errorMessage;
+        this.gameId = gameId;
     }
 
     public Integer getErrorCode() {
@@ -16,5 +21,9 @@ public class RegisterGameFailedErrorDto {
 
     public String getErrorMessage() {
         return errorMessage;
+    }
+
+    public Long getGameId() {
+        return gameId;
     }
 }

--- a/src/main/java/kr/megaptera/smash/exceptions/RegisterGameFailed.java
+++ b/src/main/java/kr/megaptera/smash/exceptions/RegisterGameFailed.java
@@ -1,7 +1,18 @@
 package kr.megaptera.smash.exceptions;
 
 public class RegisterGameFailed extends RuntimeException {
+    private Long gameId;
+
     public RegisterGameFailed(String message) {
         super(message);
+    }
+
+    public RegisterGameFailed(String message, Long gameId) {
+        super(message);
+        this.gameId = gameId;
+    }
+
+    public Long getGameId() {
+        return gameId;
     }
 }

--- a/src/test/java/kr/megaptera/smash/controllers/RegisterControllerTest.java
+++ b/src/test/java/kr/megaptera/smash/controllers/RegisterControllerTest.java
@@ -212,6 +212,21 @@ class RegisterControllerTest {
     }
 
     @Test
+    void registerGameFailedWithFullyParticipants() throws Exception {
+        given(postRegisterGameService.registerGame(gameId, userId))
+            .willThrow(new RegisterGameFailed(
+                "참가 정원이 모두 차 참가를 신청할 수 없습니다."));
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/registers/games/1")
+                .header("Authorization", "Bearer " + token))
+            .andExpect(MockMvcResultMatchers.status().isBadRequest())
+            .andExpect(MockMvcResultMatchers.content().string(
+                containsString("103")
+            ))
+        ;
+    }
+
+    @Test
     void cancelRegister() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.patch("/registers/4")
                 .header("Authorization", "Bearer " + token)

--- a/src/test/java/kr/megaptera/smash/services/PostRegisterGameServiceTest.java
+++ b/src/test/java/kr/megaptera/smash/services/PostRegisterGameServiceTest.java
@@ -209,4 +209,54 @@ class PostRegisterGameServiceTest {
         verify(userRepository, never()).findById(notExistedUserId);
         verify(registerRepository, never()).save(any(Register.class));
     }
+
+    @Test
+    void registerGameWithFullyParticipants() {
+        Long gameId = 1L;
+        Game game = new Game(
+            gameId,
+            1L,
+            new Exercise("운동 종류"),
+            new GameDateTime(
+                LocalDate.of(2022, 10, 20),
+                LocalTime.of(14, 0),
+                LocalTime.of(17, 0)
+            ),
+            new Place("운동 장소"),
+            new GameTargetMemberCount(2)
+        );
+        given(gameRepository.findById(gameId)).willReturn(Optional.of(game));
+
+        List<Register> members = List.of(
+            new Register(
+                1L,
+                2L,
+                gameId,
+                new RegisterStatus(RegisterStatus.ACCEPTED)),
+            new Register(
+                2L,
+                3L,
+                gameId,
+                new RegisterStatus(RegisterStatus.ACCEPTED))
+        );
+        given(registerRepository.findByGameId(gameId)).willReturn(members);
+
+        Long userId = 1L;
+        User user = new User(
+            userId,
+            new UserAccount("MinjiRungRung12"),
+            new UserName("민지룽룽"),
+            new UserGender("여성"),
+            new UserPhoneNumber("010-2222-2222")
+        );
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        assertThrows(RegisterGameFailed.class, () -> {
+            postRegisterGameService.registerGame(gameId, userId);
+        });
+
+        verify(gameRepository).findById(gameId);
+        verify(registerRepository).findByGameId(gameId);
+        verify(registerRepository, never()).save(any(Register.class));
+    }
 }


### PR DESCRIPTION
다음의 상황에 대응하는 예외처리를 수행
- 사용자가 잔여석이 남은 게시글 목록이나 게시글 상세 내용을 조회해 신청하기 버튼이 있는 것을 확인
- 다른 사용자가 게시글에 참가를 신청하고, 작성자가 신청을 수락해 잔여석이 없게 만듦
- 사용자가 잔여석이 없게 된 해당 게시글에 신청하기 버튼 클릭 시 '정원이 모두 찼습니다.' 메세지를 띄움

예외 에러 DTO에 예외가 발생한 gameId를 같이 전달
게시글 목록 조회 시 예외가 발생한 gameId를 갖는 게시물에만 예외 메세지가 출력되도록 함

https://github.com/hsjkdss228/smash-frontend/pull/35