### PR TITLE
알림 객체 정의, 알림 목록 GET 요청 처리, 신청/수락 동작 시 대상 사용자에게 알림 생성

### DIFF
--- a/src/main/java/kr/megaptera/smash/controllers/NoticeController.java
+++ b/src/main/java/kr/megaptera/smash/controllers/NoticeController.java
@@ -1,0 +1,25 @@
+package kr.megaptera.smash.controllers;
+
+import kr.megaptera.smash.dtos.NoticesDto;
+import kr.megaptera.smash.services.GetNoticesService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("notices")
+public class NoticeController {
+    private final GetNoticesService getNoticesService;
+
+    public NoticeController(GetNoticesService getNoticesService) {
+        this.getNoticesService = getNoticesService;
+    }
+
+    @GetMapping
+    public NoticesDto notices(
+        @RequestAttribute("userId") Long currentUserId
+    ) {
+        return getNoticesService.findAllNoticesOfUser(currentUserId);
+    }
+}

--- a/src/main/java/kr/megaptera/smash/controllers/RegisterController.java
+++ b/src/main/java/kr/megaptera/smash/controllers/RegisterController.java
@@ -4,6 +4,7 @@ import kr.megaptera.smash.dtos.RegisterGameResultDto;
 import kr.megaptera.smash.exceptions.AlreadyJoinedGame;
 import kr.megaptera.smash.exceptions.GameIsFull;
 import kr.megaptera.smash.exceptions.GameNotFound;
+import kr.megaptera.smash.exceptions.PostNotFound;
 import kr.megaptera.smash.exceptions.UserNotFound;
 import kr.megaptera.smash.services.PatchRegisterToAcceptedService;
 import kr.megaptera.smash.services.PatchRegisterToCanceledService;
@@ -74,6 +75,12 @@ public class RegisterController {
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public String gameNotFound() {
         return "Game Not Found";
+    }
+
+    @ExceptionHandler(PostNotFound.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public String postNotFound() {
+        return "Post Not Found";
     }
 
     @ExceptionHandler(AlreadyJoinedGame.class)

--- a/src/main/java/kr/megaptera/smash/controllers/UserController.java
+++ b/src/main/java/kr/megaptera/smash/controllers/UserController.java
@@ -1,0 +1,35 @@
+package kr.megaptera.smash.controllers;
+
+import kr.megaptera.smash.dtos.UserNameDto;
+import kr.megaptera.smash.exceptions.UserNotFound;
+import kr.megaptera.smash.services.GetUserNameService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("users")
+public class UserController {
+    private final GetUserNameService getUserNameService;
+
+    public UserController(GetUserNameService getUserNameService) {
+        this.getUserNameService = getUserNameService;
+    }
+
+    @GetMapping("me")
+    public UserNameDto userName(
+        @RequestAttribute("userId") Long currentUserId
+    ) {
+        return getUserNameService.getUserName(currentUserId);
+    }
+
+    @ExceptionHandler(UserNotFound.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public String userNotFound() {
+        return "User Not Found";
+    }
+}

--- a/src/main/java/kr/megaptera/smash/dtos/NoticeListDto.java
+++ b/src/main/java/kr/megaptera/smash/dtos/NoticeListDto.java
@@ -1,0 +1,30 @@
+package kr.megaptera.smash.dtos;
+
+public class NoticeListDto {
+    private final Long id;
+
+    private final String createdAt;
+
+    private final String title;
+
+    public NoticeListDto(Long id,
+                         String createdAt,
+                         String title
+    ) {
+        this.id = id;
+        this.createdAt = createdAt;
+        this.title = title;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+}

--- a/src/main/java/kr/megaptera/smash/dtos/NoticesDto.java
+++ b/src/main/java/kr/megaptera/smash/dtos/NoticesDto.java
@@ -1,0 +1,15 @@
+package kr.megaptera.smash.dtos;
+
+import java.util.List;
+
+public class NoticesDto {
+    private final List<NoticeListDto> notices;
+
+    public NoticesDto(List<NoticeListDto> notices) {
+        this.notices = notices;
+    }
+
+    public List<NoticeListDto> getNotices() {
+        return notices;
+    }
+}

--- a/src/main/java/kr/megaptera/smash/dtos/UserNameDto.java
+++ b/src/main/java/kr/megaptera/smash/dtos/UserNameDto.java
@@ -1,0 +1,13 @@
+package kr.megaptera.smash.dtos;
+
+public class UserNameDto {
+    private final String name;
+
+    public UserNameDto(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/kr/megaptera/smash/models/Game.java
+++ b/src/main/java/kr/megaptera/smash/models/Game.java
@@ -226,10 +226,38 @@ public class Game {
         );
     }
 
+    public static Game fake(String exerciseName,
+                            GameDateTime gameDateTime) {
+        return new Game(
+            1L,
+            1L,
+            new Exercise(exerciseName),
+            gameDateTime,
+            new Place("운동 장소"),
+            new GameTargetMemberCount(10)
+        );
+    }
+
     public static Game fake(GameTargetMemberCount targetMemberCount) {
         return new Game(
             1L,
             1L,
+            new Exercise("운동 이름"),
+            new GameDateTime(
+                LocalDate.of(2022, 12, 24),
+                LocalTime.of(10, 0),
+                LocalTime.of(16, 30)
+            ),
+            new Place("운동 장소"),
+            new GameTargetMemberCount(targetMemberCount.value())
+        );
+    }
+
+    public static Game fake(Long postId,
+                            GameTargetMemberCount targetMemberCount) {
+        return new Game(
+            1L,
+            postId,
             new Exercise("운동 이름"),
             new GameDateTime(
                 LocalDate.of(2022, 12, 24),

--- a/src/main/java/kr/megaptera/smash/models/Notice.java
+++ b/src/main/java/kr/megaptera/smash/models/Notice.java
@@ -1,0 +1,95 @@
+package kr.megaptera.smash.models;
+
+import kr.megaptera.smash.dtos.NoticeListDto;
+import org.hibernate.annotations.CreationTimestamp;
+
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notices")
+public class Notice {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private Long userId;
+
+    @Embedded
+    private NoticeContents contents;
+
+    @Embedded
+    private NoticeStatus status;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    private Notice() {
+
+    }
+
+    public Notice(Long userId,
+                  NoticeContents contents,
+                  NoticeStatus status
+    ) {
+        this.userId = userId;
+        this.contents = contents;
+        this.status = status;
+    }
+
+    public Notice(Long id,
+                  Long userId,
+                  NoticeContents contents,
+                  NoticeStatus status,
+                  LocalDateTime createdAt
+    ) {
+        this.id = id;
+        this.userId = userId;
+        this.contents = contents;
+        this.status = status;
+        this.createdAt = createdAt;
+    }
+
+    public Long userId() {
+        return userId;
+    }
+
+    public NoticeContents contents() {
+        return contents;
+    }
+
+    public NoticeStatus status() {
+        return status;
+    }
+
+    public boolean active() {
+        return status.equals(NoticeStatus.unread())
+            || status.equals(NoticeStatus.read());
+    }
+
+    public static Notice fake(NoticeStatus status) {
+        Long userId = 1L;
+        return new Notice(
+            1L,
+            userId,
+            new NoticeContents(
+                "알림 제목",
+                "알림 상세 내용"
+            ),
+            status,
+            LocalDateTime.now()
+        );
+    }
+
+    public NoticeListDto toListDto() {
+        return new NoticeListDto(
+            id,
+            createdAt.toString(),
+            contents.title()
+        );
+    }
+}

--- a/src/main/java/kr/megaptera/smash/models/NoticeContents.java
+++ b/src/main/java/kr/megaptera/smash/models/NoticeContents.java
@@ -1,0 +1,56 @@
+package kr.megaptera.smash.models;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import java.util.Objects;
+
+@Embeddable
+public class NoticeContents {
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "detail")
+    private String detail;
+
+    private NoticeContents() {
+
+    }
+
+    public NoticeContents(String title, String detail) {
+        this.title = title;
+        this.detail = detail;
+    }
+
+    public String title() {
+        return title;
+    }
+
+    public String detail() {
+        return detail;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        };
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        };
+        NoticeContents that = (NoticeContents) o;
+        return Objects.equals(title, that.title) && Objects.equals(detail, that.detail);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(title, detail);
+    }
+
+    @Override
+    public String toString() {
+        return "NoticeContents{" +
+            "title='" + title + '\'' +
+            ", detail='" + detail + '\'' +
+            '}';
+    }
+}

--- a/src/main/java/kr/megaptera/smash/models/NoticeStatus.java
+++ b/src/main/java/kr/megaptera/smash/models/NoticeStatus.java
@@ -1,0 +1,60 @@
+package kr.megaptera.smash.models;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import java.util.Objects;
+
+@Embeddable
+public class NoticeStatus {
+    private static final NoticeStatus UNREAD
+         = new NoticeStatus("unread");
+    private static final NoticeStatus READ
+        = new NoticeStatus("read");
+    private static final NoticeStatus DELETED
+        = new NoticeStatus("deleted");
+
+    @Column(name = "status")
+    private String value;
+
+    private NoticeStatus() {
+
+    }
+
+    public NoticeStatus(String value) {
+        this.value = value;
+    }
+
+    public static NoticeStatus unread() {
+        return UNREAD;
+    }
+
+    public static NoticeStatus read() {
+        return READ;
+    }
+
+    public static NoticeStatus deleted() {
+        return DELETED;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        NoticeStatus that = (NoticeStatus) o;
+        return Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/src/main/java/kr/megaptera/smash/models/Register.java
+++ b/src/main/java/kr/megaptera/smash/models/Register.java
@@ -99,6 +99,30 @@ public class Register {
         status = RegisterStatus.rejected();
     }
 
+    public Notice createRegisterNotice(User currentUser,
+                                       User postAuthor) {
+        return new Notice(
+            postAuthor.id(),
+            new NoticeContents(
+                "작성한 모집 게시글에 새로운 신청이 등록되었습니다.",
+                "등록한 신청자: " + currentUser.name().toString()
+            ),
+            NoticeStatus.unread()
+        );
+    }
+
+    public Notice createAcceptNotice(User user, Game game) {
+        return new Notice(
+            user.id(),
+            new NoticeContents(
+                "신청한 운동 모집 게시글에 참가가 확정되었습니다.",
+                "신청한 게임 종목: " + game.exercise() + "\n"
+                + "신청한 게임 시간: " + game.dateTime().joinDateAndTime()
+            ),
+            NoticeStatus.unread()
+        );
+    }
+
     // TODO: UserId, GameId 값 객체를 정의해 Long으로 부여하는 파라미터를 대체
 
     public static Register fake(Long userId, Long gameId) {
@@ -109,7 +133,9 @@ public class Register {
         );
     }
 
-    public static Register fake(Long userId, Long gameId, RegisterStatus status) {
+    public static Register fake(Long userId,
+                                Long gameId,
+                                RegisterStatus status) {
         return new Register(
             userId,
             gameId,
@@ -149,7 +175,8 @@ public class Register {
         );
     }
 
-    public static List<Register> fakesAccepted(long generationCount, long gameId) {
+    public static List<Register> fakesAccepted(long generationCount,
+                                               long gameId) {
         List<Register> registers = new ArrayList<>();
         for (long id = 1; id <= generationCount; id += 1) {
             Long userId = id;
@@ -164,7 +191,8 @@ public class Register {
         return registers;
     }
 
-    public static List<Register> fakesProcessing(long generationCount, long gameId) {
+    public static List<Register> fakesProcessing(long generationCount,
+                                                 long gameId) {
         List<Register> registers = new ArrayList<>();
         for (long id = 1; id <= generationCount; id += 1) {
             Long userId = id;

--- a/src/main/java/kr/megaptera/smash/repositories/NoticeRepository.java
+++ b/src/main/java/kr/megaptera/smash/repositories/NoticeRepository.java
@@ -1,0 +1,10 @@
+package kr.megaptera.smash.repositories;
+
+import kr.megaptera.smash.models.Notice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+    List<Notice> findAllByUserId(Long userId);
+}

--- a/src/main/java/kr/megaptera/smash/services/GetNoticesService.java
+++ b/src/main/java/kr/megaptera/smash/services/GetNoticesService.java
@@ -1,0 +1,38 @@
+package kr.megaptera.smash.services;
+
+import kr.megaptera.smash.dtos.NoticeListDto;
+import kr.megaptera.smash.dtos.NoticesDto;
+import kr.megaptera.smash.models.Notice;
+import kr.megaptera.smash.repositories.NoticeRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class GetNoticesService {
+    private final NoticeRepository noticeRepository;
+
+    public GetNoticesService(NoticeRepository noticeRepository) {
+        this.noticeRepository = noticeRepository;
+    }
+
+    public NoticesDto findAllNoticesOfUser(Long currentUserId) {
+        List<Notice> notices
+            = noticeRepository.findAllByUserId(currentUserId);
+
+        // TODO: 삭제 상태의 알림들은 가져오지 않아야 한다.
+
+        // TODO: 이 동작조차도 객체의 동작 안에 숨어야 하는 것 같다.
+        //   꺼내온 알림들을 DTO로 만드는 건 도대체 누구의 책임인가?
+        //   알림판? 그럼 게시판-게시물의 관계인가?
+        //   동작을 수행할 적절한 객체를 찾아 정의한 뒤에는 그 객체의 동작으로 옮기기
+        List<NoticeListDto> noticeListDtos = notices.stream()
+            .filter(Notice::active)
+            .map(Notice::toListDto)
+            .toList();
+
+        return new NoticesDto(noticeListDtos);
+    }
+}

--- a/src/main/java/kr/megaptera/smash/services/GetUserNameService.java
+++ b/src/main/java/kr/megaptera/smash/services/GetUserNameService.java
@@ -1,0 +1,27 @@
+package kr.megaptera.smash.services;
+
+import kr.megaptera.smash.dtos.UserNameDto;
+import kr.megaptera.smash.exceptions.UserNotFound;
+import kr.megaptera.smash.models.User;
+import kr.megaptera.smash.repositories.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class GetUserNameService {
+    private final UserRepository userRepository;
+
+    public GetUserNameService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public UserNameDto getUserName(Long currentUserId) {
+        User user = userRepository.findById(currentUserId)
+            .orElseThrow(() -> new UserNotFound(currentUserId));
+
+        String name = user.name().toString();
+
+        return new UserNameDto(name);
+    }
+}

--- a/src/main/java/kr/megaptera/smash/services/JoinGameService.java
+++ b/src/main/java/kr/megaptera/smash/services/JoinGameService.java
@@ -2,11 +2,16 @@ package kr.megaptera.smash.services;
 
 import kr.megaptera.smash.dtos.RegisterGameResultDto;
 import kr.megaptera.smash.exceptions.GameNotFound;
+import kr.megaptera.smash.exceptions.PostNotFound;
 import kr.megaptera.smash.exceptions.UserNotFound;
 import kr.megaptera.smash.models.Game;
+import kr.megaptera.smash.models.Notice;
+import kr.megaptera.smash.models.Post;
 import kr.megaptera.smash.models.Register;
 import kr.megaptera.smash.models.User;
 import kr.megaptera.smash.repositories.GameRepository;
+import kr.megaptera.smash.repositories.NoticeRepository;
+import kr.megaptera.smash.repositories.PostRepository;
 import kr.megaptera.smash.repositories.RegisterRepository;
 import kr.megaptera.smash.repositories.UserRepository;
 import org.springframework.stereotype.Service;
@@ -20,13 +25,19 @@ public class JoinGameService {
     private final GameRepository gameRepository;
     private final RegisterRepository registerRepository;
     private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final NoticeRepository noticeRepository;
 
     public JoinGameService(GameRepository gameRepository,
                            RegisterRepository registerRepository,
-                           UserRepository userRepository) {
+                           UserRepository userRepository,
+                           PostRepository postRepository,
+                           NoticeRepository noticeRepository) {
         this.gameRepository = gameRepository;
         this.registerRepository = registerRepository;
         this.userRepository = userRepository;
+        this.postRepository = postRepository;
+        this.noticeRepository = noticeRepository;
     }
 
     public RegisterGameResultDto joinGame(Long gameId,
@@ -41,7 +52,22 @@ public class JoinGameService {
 
         Register register = game.join(currentUser, registers);
 
-        registerRepository.save(register);
+        if (register != null) {
+            Register savedRegister = registerRepository.save(register);
+
+            Post post = postRepository.findById(game.postId())
+                .orElseThrow(PostNotFound::new);
+
+            User postAuthor = userRepository.findById(post.userId())
+                .orElseThrow(() -> new UserNotFound(post.userId()));
+
+            Notice notice = savedRegister.createRegisterNotice(
+                currentUser,
+                postAuthor
+            );
+
+            noticeRepository.save(notice);
+        }
 
         return new RegisterGameResultDto(gameId);
     }

--- a/src/main/java/kr/megaptera/smash/services/PatchRegisterToAcceptedService.java
+++ b/src/main/java/kr/megaptera/smash/services/PatchRegisterToAcceptedService.java
@@ -1,8 +1,16 @@
 package kr.megaptera.smash.services;
 
+import kr.megaptera.smash.exceptions.GameNotFound;
 import kr.megaptera.smash.exceptions.RegisterNotFound;
+import kr.megaptera.smash.exceptions.UserNotFound;
+import kr.megaptera.smash.models.Game;
+import kr.megaptera.smash.models.Notice;
 import kr.megaptera.smash.models.Register;
+import kr.megaptera.smash.models.User;
+import kr.megaptera.smash.repositories.GameRepository;
+import kr.megaptera.smash.repositories.NoticeRepository;
 import kr.megaptera.smash.repositories.RegisterRepository;
+import kr.megaptera.smash.repositories.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,9 +18,18 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class PatchRegisterToAcceptedService {
     private final RegisterRepository registerRepository;
+    private final UserRepository userRepository;
+    private final GameRepository gameRepository;
+    private final NoticeRepository noticeRepository;
 
-    public PatchRegisterToAcceptedService(RegisterRepository registerRepository) {
+    public PatchRegisterToAcceptedService(RegisterRepository registerRepository,
+                                          UserRepository userRepository,
+                                          GameRepository gameRepository,
+                                          NoticeRepository noticeRepository) {
         this.registerRepository = registerRepository;
+        this.userRepository = userRepository;
+        this.gameRepository = gameRepository;
+        this.noticeRepository = noticeRepository;
     }
 
     public void patchRegisterToAccepted(Long registerId) {
@@ -21,5 +38,17 @@ public class PatchRegisterToAcceptedService {
             .orElseThrow(RegisterNotFound::new);
 
         register.acceptRegister();
+
+        if (register.accepted()) {
+            User user = userRepository.findById(register.userId())
+                .orElseThrow(() -> new UserNotFound(register.userId()));
+
+            Game game = gameRepository.findById(register.gameId())
+                .orElseThrow(GameNotFound::new);
+
+            Notice notice = register.createAcceptNotice(user, game);
+
+            noticeRepository.save(notice);
+        }
     }
 }

--- a/src/test/java/kr/megaptera/smash/controllers/NoticeControllerTest.java
+++ b/src/test/java/kr/megaptera/smash/controllers/NoticeControllerTest.java
@@ -1,0 +1,68 @@
+package kr.megaptera.smash.controllers;
+
+import kr.megaptera.smash.config.MockMvcEncoding;
+import kr.megaptera.smash.dtos.NoticeListDto;
+import kr.megaptera.smash.dtos.NoticesDto;
+import kr.megaptera.smash.services.GetNoticesService;
+import kr.megaptera.smash.utils.JwtUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+
+@MockMvcEncoding
+@WebMvcTest(NoticeController.class)
+class NoticeControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private GetNoticesService getNoticesService;
+
+    @SpyBean
+    private JwtUtil jwtUtil;
+
+    private NoticesDto noticesDto;
+
+    // TODO: 모델을 정의하고 fake와 toDto 메서드를 정의하고 난 뒤에는
+    //    fake().toDto() 형태로 대체하기
+
+    @BeforeEach
+    void setUp() {
+        List<NoticeListDto> noticeListDtos = List.of(
+            new NoticeListDto(
+                1L,
+                "3시간 전",
+                "내가 신청한 운동 모집 게시글의 작성자가 신청을 수락했습니다."
+            ),
+            new NoticeListDto(
+                2L,
+                "6시간 전",
+                "내가 작성한 운동 모집 게시글에 새로운 참가 신청이 있습니다."
+            )
+        );
+        noticesDto = new NoticesDto(noticeListDtos);
+    }
+
+    @Test
+    void notices() throws Exception {
+        Long userId = 1L;
+        given(getNoticesService.findAllNoticesOfUser(userId))
+            .willReturn(noticesDto);
+
+        String token = jwtUtil.encode(userId);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/notices")
+                .header("Authorization", "Bearer " + token))
+            .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+}

--- a/src/test/java/kr/megaptera/smash/controllers/UserControllerTest.java
+++ b/src/test/java/kr/megaptera/smash/controllers/UserControllerTest.java
@@ -1,0 +1,61 @@
+package kr.megaptera.smash.controllers;
+
+import kr.megaptera.smash.config.MockMvcEncoding;
+import kr.megaptera.smash.dtos.UserNameDto;
+import kr.megaptera.smash.exceptions.UserNotFound;
+import kr.megaptera.smash.services.GetUserNameService;
+import kr.megaptera.smash.utils.JwtUtil;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.BDDMockito.given;
+
+@MockMvcEncoding
+@WebMvcTest(UserController.class)
+class UserControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private GetUserNameService getUserNameService;
+
+    @SpyBean
+    private JwtUtil jwtUtil;
+
+    @Test
+    void userName() throws Exception {
+        Long userId = 1L;
+        String token = jwtUtil.encode(userId);
+
+        UserNameDto userNameDto = new UserNameDto("황인우");
+        given(getUserNameService.getUserName(userId))
+            .willReturn(userNameDto);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/users/me")
+            .header("Authorization", "Bearer " + token))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.content().string(
+                containsString("황인우")
+            ));
+    }
+
+    @Test
+    void userNameWithUserNotFound() throws Exception {
+        Long userId = 1L;
+        String token = jwtUtil.encode(userId);
+
+        given(getUserNameService.getUserName(userId))
+            .willThrow(UserNotFound.class);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/users/me")
+                .header("Authorization", "Bearer " + token))
+            .andExpect(MockMvcResultMatchers.status().isNotFound());
+    }
+}

--- a/src/test/java/kr/megaptera/smash/models/NoticeTest.java
+++ b/src/test/java/kr/megaptera/smash/models/NoticeTest.java
@@ -1,0 +1,18 @@
+package kr.megaptera.smash.models;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NoticeTest {
+    @Test
+    void active() {
+        Notice noticeUnread = Notice.fake(NoticeStatus.unread());
+        Notice noticeRead = Notice.fake(NoticeStatus.read());
+        Notice noticeDeleted = Notice.fake(NoticeStatus.deleted());
+
+        assertThat(noticeUnread.active()).isTrue();
+        assertThat(noticeRead.active()).isTrue();
+        assertThat(noticeDeleted.active()).isFalse();
+    }
+}

--- a/src/test/java/kr/megaptera/smash/models/RegisterTest.java
+++ b/src/test/java/kr/megaptera/smash/models/RegisterTest.java
@@ -2,6 +2,9 @@ package kr.megaptera.smash.models;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class RegisterTest {
@@ -76,5 +79,47 @@ class RegisterTest {
             = Register.fake(userId, gameId, RegisterStatus.processing());
         register.rejectRegister();
         assertThat(register.status()).isEqualTo(RegisterStatus.rejected());
+    }
+
+    @Test
+    void createRegisterNotice() {
+        User user = User.fake("신청자 1", "username");
+        Long postAuthorId = 2L;
+        User postAuthor = User.fake(postAuthorId);
+
+        Long gameId = 1L;
+        Register register = Register.fake(user.id(), gameId);
+
+        Notice notice = register.createRegisterNotice(user, postAuthor);
+        assertThat(notice.userId()).isEqualTo(postAuthorId);
+        assertThat(notice.contents().title()).contains("신청이 등록되었습니다.");
+        assertThat(notice.contents().detail()).isEqualTo("등록한 신청자: 신청자 1");
+        assertThat(notice.status()).isEqualTo(NoticeStatus.unread());
+    }
+
+    @Test
+    void createAcceptNotice() {
+        Long userId = 1L;
+        User user = User.fake(userId);
+
+        Long gameId = 1L;
+        Game game = Game.fake(
+            "운동 이름",
+            new GameDateTime(
+                LocalDate.of(2022, 12, 25),
+                LocalTime.of(12, 30),
+                LocalTime.of(15, 0)
+            )
+        );
+        Register register = Register.fakeAccepted(game.id(), user.id());
+
+        Notice notice = register.createAcceptNotice(user, game);
+        assertThat(notice.userId()).isEqualTo(user.id());
+        assertThat(notice.contents().title()).contains("참가가 확정되었습니다.");
+        assertThat(notice.contents().detail())
+            .contains("운동 이름");
+        assertThat(notice.contents().detail())
+            .contains("2022년 12월 25일 오후 12:30 ~ 오후 03:00");
+        assertThat(notice.status()).isEqualTo(NoticeStatus.unread());
     }
 }

--- a/src/test/java/kr/megaptera/smash/services/GetNoticesServiceTest.java
+++ b/src/test/java/kr/megaptera/smash/services/GetNoticesServiceTest.java
@@ -1,0 +1,81 @@
+package kr.megaptera.smash.services;
+
+import kr.megaptera.smash.dtos.NoticeListDto;
+import kr.megaptera.smash.dtos.NoticesDto;
+import kr.megaptera.smash.models.Notice;
+import kr.megaptera.smash.models.NoticeContents;
+import kr.megaptera.smash.models.NoticeStatus;
+import kr.megaptera.smash.repositories.NoticeRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+class GetNoticesServiceTest {
+    private GetNoticesService getNoticesService;
+
+    private NoticeRepository noticeRepository;
+
+    @BeforeEach
+    void setUp() {
+        noticeRepository = mock(NoticeRepository.class);
+        getNoticesService = new GetNoticesService(noticeRepository);
+    }
+
+    @Test
+    void findAllNoticesOfUser() {
+        // TODO: 필요한 인터페이스를 고려해 fake() 형태로 대체하기
+
+        Long userId = 1L;
+
+        List<Notice> notices = List.of(
+            new Notice(
+                1L,
+                userId,
+                new NoticeContents(
+                    "알림 제목",
+                    "알림 상세 내용"
+                ),
+                NoticeStatus.unread(),
+                LocalDateTime.now()
+            ),
+            new Notice(
+                2L,
+                userId,
+                new NoticeContents(
+                    "알림 제목",
+                    "알림 상세 내용"
+                ),
+                NoticeStatus.read(),
+                LocalDateTime.now()
+            ),
+            new Notice(
+                3L,
+                userId,
+                new NoticeContents(
+                    "알림 제목",
+                    "알림 상세 내용"
+                ),
+                NoticeStatus.deleted(),
+                LocalDateTime.now()
+            )
+        );
+
+        given(noticeRepository.findAllByUserId(userId))
+            .willReturn(notices);
+
+        NoticesDto noticesDto
+            = getNoticesService.findAllNoticesOfUser(userId);
+
+        assertThat(noticesDto).isNotNull();
+        List<NoticeListDto> noticeListDtos = noticesDto.getNotices();
+        assertThat(noticeListDtos).hasSize(2);
+        // TODO: 시간 변환 로직을 구현할 경우 시간 변환이 정상적으로 되었는지 테스트
+        assertThat(noticeListDtos.get(1).getTitle()).isEqualTo("알림 제목");
+    }
+}

--- a/src/test/java/kr/megaptera/smash/services/GetUserNameServiceTest.java
+++ b/src/test/java/kr/megaptera/smash/services/GetUserNameServiceTest.java
@@ -1,0 +1,55 @@
+package kr.megaptera.smash.services;
+
+import kr.megaptera.smash.dtos.UserNameDto;
+import kr.megaptera.smash.exceptions.UserNotFound;
+import kr.megaptera.smash.models.User;
+import kr.megaptera.smash.repositories.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class GetUserNameServiceTest {
+    private GetUserNameService getUserNameService;
+
+    private UserRepository userRepository;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        getUserNameService = new GetUserNameService(userRepository);
+    }
+
+    @Test
+    void getUserName() {
+        Long userId = 1L;
+        User user = User.fake("치코리타", "chikorita");
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        UserNameDto userNameDto = getUserNameService.getUserName(userId);
+
+        assertThat(userNameDto).isNotNull();
+        assertThat(userNameDto.getName()).isEqualTo("치코리타");
+
+        verify(userRepository).findById(userId);
+    }
+
+    @Test
+    void getUserNameWithUserNotFound() {
+        Long wrongUserId = 2222L;
+
+        given(userRepository.findById(wrongUserId))
+            .willThrow(UserNotFound.class);
+
+        assertThrows(UserNotFound.class, () -> {
+            getUserNameService.getUserName(wrongUserId);
+        });
+    }
+}

--- a/src/test/java/kr/megaptera/smash/services/JoinGameServiceTest.java
+++ b/src/test/java/kr/megaptera/smash/services/JoinGameServiceTest.java
@@ -5,10 +5,14 @@ import kr.megaptera.smash.exceptions.GameNotFound;
 import kr.megaptera.smash.exceptions.UserNotFound;
 import kr.megaptera.smash.models.Game;
 import kr.megaptera.smash.models.GameTargetMemberCount;
+import kr.megaptera.smash.models.Notice;
+import kr.megaptera.smash.models.Post;
 import kr.megaptera.smash.models.Register;
 import kr.megaptera.smash.models.RegisterStatus;
 import kr.megaptera.smash.models.User;
 import kr.megaptera.smash.repositories.GameRepository;
+import kr.megaptera.smash.repositories.NoticeRepository;
+import kr.megaptera.smash.repositories.PostRepository;
 import kr.megaptera.smash.repositories.RegisterRepository;
 import kr.megaptera.smash.repositories.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,32 +34,41 @@ class JoinGameServiceTest {
     private GameRepository gameRepository;
     private RegisterRepository registerRepository;
     private UserRepository userRepository;
+    private PostRepository postRepository;
+    private NoticeRepository noticeRepository;
 
     @BeforeEach
     void setUp() {
         gameRepository = mock(GameRepository.class);
         registerRepository = mock(RegisterRepository.class);
         userRepository = mock(UserRepository.class);
+        postRepository = mock(PostRepository.class);
+        noticeRepository = mock(NoticeRepository.class);
 
         joinGameService = new JoinGameService(
             gameRepository,
             registerRepository,
-            userRepository
-        );
+            userRepository,
+            postRepository,
+            noticeRepository);
     }
-
-    // TODO: Service에서 발생하는 에러 검증하는 테스트 코드 작성
-    //   UserNotFound, GameNotFound
 
     @Test
     void joinGame() {
+        Long postId = 1L;
+        Long postAuthorId = 1L;
+        User postAuthor = User.fake(postAuthorId);
+        Post post = Post.fake(postId, postAuthor.id());
+
         Long userId = 4L;
         User user = User.fake(userId);
-        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(userRepository.findById(userId))
+            .willReturn(Optional.of(user));
 
         Long gameId = 1L;
-        Game game = Game.fake(new GameTargetMemberCount(3));
-        given(gameRepository.findById(gameId)).willReturn(Optional.of(game));
+        Game game = Game.fake(post.id(), new GameTargetMemberCount(3));
+        given(gameRepository.findById(gameId))
+            .willReturn(Optional.of(game));
 
         List<Register> registers = List.of(
             Register.fake(1L, game.id(), RegisterStatus.accepted()),
@@ -65,12 +78,23 @@ class JoinGameServiceTest {
         given(registerRepository.findByGameId(game.id()))
             .willReturn(registers);
 
+        Register register = Register.fakeProcessing(user.id(), game.id());
+        given(registerRepository.save(any(Register.class)))
+            .willReturn(register);
+
+        given(postRepository.findById(game.postId()))
+            .willReturn(Optional.of(post));
+
+        given(userRepository.findById(post.userId()))
+            .willReturn(Optional.of(postAuthor));
+
         RegisterGameResultDto registerGameResultDto
             = joinGameService.joinGame(gameId, userId);
 
         assertThat(registerGameResultDto.getGameId()).isEqualTo(1L);
 
         verify(registerRepository).save(any(Register.class));
+        verify(noticeRepository).save(any(Notice.class));
     }
 
     @Test

--- a/src/test/java/kr/megaptera/smash/services/PatchRegisterToAcceptedServiceTest.java
+++ b/src/test/java/kr/megaptera/smash/services/PatchRegisterToAcceptedServiceTest.java
@@ -1,13 +1,19 @@
 package kr.megaptera.smash.services;
 
+import kr.megaptera.smash.models.Game;
+import kr.megaptera.smash.models.Notice;
 import kr.megaptera.smash.models.Register;
-import kr.megaptera.smash.models.RegisterStatus;
+import kr.megaptera.smash.models.User;
+import kr.megaptera.smash.repositories.GameRepository;
+import kr.megaptera.smash.repositories.NoticeRepository;
 import kr.megaptera.smash.repositories.RegisterRepository;
+import kr.megaptera.smash.repositories.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -17,32 +23,48 @@ class PatchRegisterToAcceptedServiceTest {
     private PatchRegisterToAcceptedService patchRegisterToAcceptedService;
 
     private RegisterRepository registerRepository;
+    private UserRepository userRepository;
+    private GameRepository gameRepository;
+    private NoticeRepository noticeRepository;
 
     @BeforeEach
     void setUp() {
         registerRepository = mock(RegisterRepository.class);
+        userRepository = mock(UserRepository.class);
+        gameRepository = mock(GameRepository.class);
+        noticeRepository = mock(NoticeRepository.class);
 
-        patchRegisterToAcceptedService
-            = new PatchRegisterToAcceptedService(registerRepository);
+        patchRegisterToAcceptedService = new PatchRegisterToAcceptedService(
+            registerRepository,
+            userRepository,
+            gameRepository,
+            noticeRepository);
     }
 
     @Test
     void makeGameApplicantToMember() {
         Long registerId = 12L;
         Long userId = 1L;
-        Register register = spy(new Register(
-            1L,
-            userId,
-            1L,
-            RegisterStatus.processing()
-        ));
+        Long gameId = 1L;
+
+        User user = User.fake(userId);
+        Game game = Game.fake(gameId);
+        Register register = spy(Register.fakeProcessing(userId, gameId));
 
         given(registerRepository.findById(registerId))
             .willReturn(Optional.of(register));
+
+        given(userRepository.findById(register.userId()))
+            .willReturn(Optional.of(user));
+
+        given(gameRepository.findById(register.gameId()))
+            .willReturn(Optional.of(game));
 
         patchRegisterToAcceptedService.patchRegisterToAccepted(registerId);
 
         verify(registerRepository).findById(registerId);
         verify(register).acceptRegister();
+        verify(register).createAcceptNotice(user, game);
+        verify(noticeRepository).save(any(Notice.class));
     }
 }


### PR DESCRIPTION
알림이란? (notice)
: 사용자가 확인할 수 있는 메시지

어떤 알림이 있을 수 있겠는가?
지금 상태에서는
- 사용자가 참가를 신청하면 -> 알림이 -> 작성자에게 전달됨
- 작성자가 참가를 수락하면 -> 알림이 -> 사용자에게 전달됨

알림이 생성되는 시점은?
Register가 생성되거나 변경되는 시점
Register가 삭제되는 시점 (작업이 커질 수도 있으니 별도 작업으로 분리)

알림 생성의 주체는?
- 신청 상태가 생성?
  신청 상태 자신이, 자신의 변경을 알림을 통해 대신 알려주는 느낌으로 신청 상태에게 책임을 부여
  이 방식의 장점이라면 나중에 신청뿐만 아니라 다른 알림이 생성되더라도 그 변경의 주체에게 알림 생성 권한을 줄 수 있을 것 같음
  알림이 하나의 알림 생성소 같은 곳에서 생성되는게 좋은지, 특정 알림이 발생되는 시점에 그 주체가 알림을 생성하도록 하는 게 좋을지는 봐야 얄겠지만, 일단은 특정 이벤트의 주체가 알림을 생성하는 식으로 해 보자.
- 사용자가 생성하거나 변경?
  마치 사용자가 다른 사용자에게 문자 메시지를 보내는 느낌
  처음에는 사용자에게 너무 많은 권한이 집중되는 것일 것 같아 보류했으나, 알림의 상태를 읽은 상태로 변경하는 것은 사용자의 역할인 것 같아 사용자에게도 역할을 주기로 함

알림의 동작은?
아직까지는 알림이 어떤 행위를 할 수 있을지 모르겠다. 작성하다 보면 나올까?

REST API: /notices

- 사용자가 참가 신청 시 작성자에게 새로운 알림 생성
joinGameService에서 게임에 대한 신청이 생성되었을 때, 게임이 연결된 게시물을 생성한 작성자에게 알람이 전달되어야 한다.
register가 생성되었으면 -> game id로 게시물을, 게시물의 userId로 작성자를 찾는다. -> register가 찾은 작성자를 이용해 알림을 생성한다.

- 작성자가 참가신청 수락 시 사용자에게 새로운 알림 생성
patchRegisterToAcceptedService에서 사용자의 신청을 수락했을 때, 해당 사용자에게 알림이 전달되어야 한다.
register의 상태가 바뀌었으면 -> register의 userId로 사용자를, gameId로 신청한 게임을 찾는다. -> register가 찾은 사용자와 game을 이용해 알림을 생성한다.

예상 뽀모 5
실제 뽀모 8