### PR TITLE
참가 정원이 가득 찬 상태에서 참가신청 수락 요청이 들어온 경우 예외처리

### DIFF
--- a/src/main/java/kr/megaptera/smash/models/Game.java
+++ b/src/main/java/kr/megaptera/smash/models/Game.java
@@ -202,6 +202,15 @@ public class Game {
         return targetMemberCount.reach(count);
     }
 
+    public boolean isFull(List<Register> registers) {
+        this.registers = registers;
+
+        long count = registers.stream()
+            .filter(Register::accepted)
+            .count();
+        return targetMemberCount.reach(count);
+    }
+
     public static Game fake(Long gameId) {
         return new Game(
             gameId,
@@ -263,6 +272,23 @@ public class Game {
                             GameTargetMemberCount targetMemberCount) {
         return new Game(
             1L,
+            postId,
+            new Exercise("운동 이름"),
+            new GameDateTime(
+                LocalDate.of(2022, 12, 24),
+                LocalTime.of(10, 0),
+                LocalTime.of(16, 30)
+            ),
+            new Place("운동 장소"),
+            new GameTargetMemberCount(targetMemberCount.value())
+        );
+    }
+
+    public static Game fake(Long gameId,
+                            Long postId,
+                            GameTargetMemberCount targetMemberCount) {
+        return new Game(
+            gameId,
             postId,
             new Exercise("운동 이름"),
             new GameDateTime(

--- a/src/test/java/kr/megaptera/smash/controllers/RegisterControllerTest.java
+++ b/src/test/java/kr/megaptera/smash/controllers/RegisterControllerTest.java
@@ -24,6 +24,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 
 @MockMvcEncoding
@@ -162,6 +163,24 @@ class RegisterControllerTest {
                 .header("Authorization", "Bearer " + token)
                 .param("status", "accepted"))
             .andExpect(MockMvcResultMatchers.status().isNoContent());
+
+        verify(patchRegisterToAcceptedService).patchRegisterToAccepted(registerId);
+    }
+
+    @Test
+    void acceptRegisterFailWithGameIsFull() throws Exception {
+        Long registerId = 16L;
+        Long userId = 1L;
+
+        String token = jwtUtil.encode(userId);
+
+        doThrow(GameIsFull.class).doNothing()
+            .when(patchRegisterToAcceptedService).patchRegisterToAccepted(registerId);
+
+        mockMvc.perform(MockMvcRequestBuilders.patch("/registers/16")
+                .header("Authorization", "Bearer " + token)
+                .param("status", "accepted"))
+            .andExpect(MockMvcResultMatchers.status().isBadRequest());
 
         verify(patchRegisterToAcceptedService).patchRegisterToAccepted(registerId);
     }


### PR DESCRIPTION
프론트엔드
참가자가 가득 찼을 경우 작성자가 운동 참가 신청을 수락할 수 없음
(신청 버튼이 blur 처리되어 클릭할 수 없음)

백엔드
참가자가 가득 찬 상태에서 수락 요청이 들어오는 경우 예외처리
과정
- register를 accept 상태로 변경하기 전, register가 속한 game을 찾아 게임에 속한 모든 register들을 찾음
- game에 인원이 모두 찼는지를 game.isFull(registers)로 검사
- 인원이 모두 찼으면 GameIsFull을 throw, 그렇지 않다면 register를 accepted 상태로 변환하는 과정을 진행

예상 뽀모 4
실제 뽀모 2

이슈
프론트엔드 테스트 코드 수정을 상당부분 중단하고 있음
프론트엔드 테스트 코드 보완을 진행해야 함