### PR TITLE
읽지 않은 알림 개수 Count 요청 처리

### DIFF
--- a/src/main/java/kr/megaptera/smash/controllers/NoticeCountController.java
+++ b/src/main/java/kr/megaptera/smash/controllers/NoticeCountController.java
@@ -1,0 +1,27 @@
+package kr.megaptera.smash.controllers;
+
+import kr.megaptera.smash.dtos.UnreadNoticeCountDto;
+import kr.megaptera.smash.services.GetUnreadNoticeCountService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("notice-count")
+public class NoticeCountController {
+    private final GetUnreadNoticeCountService getUnreadNoticeCountService;
+
+    public NoticeCountController(GetUnreadNoticeCountService getUnreadNoticeCountService) {
+        this.getUnreadNoticeCountService = getUnreadNoticeCountService;
+    }
+
+    @GetMapping
+    public UnreadNoticeCountDto unreadNoticeCount(
+        @RequestAttribute("userId") Long currentUserId,
+        @RequestParam(value = "status") String status
+    ) {
+        return getUnreadNoticeCountService.countUnreadNotices(currentUserId);
+    }
+}

--- a/src/main/java/kr/megaptera/smash/dtos/UnreadNoticeCountDto.java
+++ b/src/main/java/kr/megaptera/smash/dtos/UnreadNoticeCountDto.java
@@ -1,0 +1,13 @@
+package kr.megaptera.smash.dtos;
+
+public class UnreadNoticeCountDto {
+    private final Long count;
+
+    public UnreadNoticeCountDto(Long count) {
+        this.count = count;
+    }
+
+    public Long getCount() {
+        return count;
+    }
+}

--- a/src/main/java/kr/megaptera/smash/models/Notice.java
+++ b/src/main/java/kr/megaptera/smash/models/Notice.java
@@ -75,6 +75,10 @@ public class Notice {
             || status.equals(NoticeStatus.read());
     }
 
+    public boolean unchecked() {
+        return status.equals(NoticeStatus.unread());
+    }
+
     public void read() {
         status = NoticeStatus.read();
     }

--- a/src/main/java/kr/megaptera/smash/services/GetUnreadNoticeCountService.java
+++ b/src/main/java/kr/megaptera/smash/services/GetUnreadNoticeCountService.java
@@ -1,0 +1,29 @@
+package kr.megaptera.smash.services;
+
+import kr.megaptera.smash.dtos.UnreadNoticeCountDto;
+import kr.megaptera.smash.models.Notice;
+import kr.megaptera.smash.repositories.NoticeRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class GetUnreadNoticeCountService {
+    private final NoticeRepository noticeRepository;
+
+    public GetUnreadNoticeCountService(NoticeRepository noticeRepository) {
+        this.noticeRepository = noticeRepository;
+    }
+
+    public UnreadNoticeCountDto countUnreadNotices(Long currentUserId) {
+        List<Notice> notices = noticeRepository.findAllByUserId(currentUserId);
+
+        Long unreadNoticeCount = notices.stream()
+            .filter(Notice::unchecked)
+            .count();
+
+        return new UnreadNoticeCountDto(unreadNoticeCount);
+    }
+}

--- a/src/test/java/kr/megaptera/smash/controllers/NoticeControllerTest.java
+++ b/src/test/java/kr/megaptera/smash/controllers/NoticeControllerTest.java
@@ -3,7 +3,9 @@ package kr.megaptera.smash.controllers;
 import kr.megaptera.smash.config.MockMvcEncoding;
 import kr.megaptera.smash.dtos.NoticeDto;
 import kr.megaptera.smash.dtos.NoticesDto;
+import kr.megaptera.smash.dtos.UnreadNoticeCountDto;
 import kr.megaptera.smash.services.GetNoticesService;
+import kr.megaptera.smash.services.GetUnreadNoticeCountService;
 import kr.megaptera.smash.services.ReadNoticeService;
 import kr.megaptera.smash.utils.JwtUtil;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,6 +20,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import java.util.List;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -36,13 +39,12 @@ class NoticeControllerTest {
     @SpyBean
     private JwtUtil jwtUtil;
 
-    private NoticesDto noticesDto;
-
     // TODO: 모델을 정의하고 fake와 toDto 메서드를 정의하고 난 뒤에는
     //    fake().toDto() 형태로 대체하기
 
-    @BeforeEach
-    void setUp() {
+    @Test
+    void notices() throws Exception {
+        Long userId = 1L;
         List<NoticeDto> noticeDtos = List.of(
             new NoticeDto(
                 1L,
@@ -59,12 +61,8 @@ class NoticeControllerTest {
                 "등록한 신청자: 신청자 이름"
             )
         );
-        noticesDto = new NoticesDto(noticeDtos);
-    }
+        NoticesDto noticesDto = new NoticesDto(noticeDtos);
 
-    @Test
-    void notices() throws Exception {
-        Long userId = 1L;
         given(getNoticesService.findAllNoticesOfUser(userId))
             .willReturn(noticesDto);
 

--- a/src/test/java/kr/megaptera/smash/controllers/NoticeCountControllerTest.java
+++ b/src/test/java/kr/megaptera/smash/controllers/NoticeCountControllerTest.java
@@ -1,0 +1,52 @@
+package kr.megaptera.smash.controllers;
+
+import kr.megaptera.smash.dtos.UnreadNoticeCountDto;
+import kr.megaptera.smash.services.GetUnreadNoticeCountService;
+import kr.megaptera.smash.utils.JwtUtil;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@WebMvcTest(NoticeCountController.class)
+class NoticeCountControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private GetUnreadNoticeCountService getUnreadNoticeCountService;
+
+    @SpyBean
+    private JwtUtil jwtUtil;
+
+    @Test
+    void unreadNoticeCount() throws Exception {
+        Long currentUserId = 1L;
+        Long unreadNoticeCount = 5L;
+        UnreadNoticeCountDto unreadNoticeCountDto
+            = new UnreadNoticeCountDto(unreadNoticeCount);
+
+        String token = jwtUtil.encode(currentUserId);
+
+        given(getUnreadNoticeCountService.countUnreadNotices(currentUserId))
+            .willReturn(unreadNoticeCountDto);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/notice-count")
+                .header("Authorization", "Bearer " + token)
+                .param("status", "unread"))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.content().string(
+                containsString("5")
+            ));
+
+        verify(getUnreadNoticeCountService).countUnreadNotices(currentUserId);
+    }
+}

--- a/src/test/java/kr/megaptera/smash/models/NoticeTest.java
+++ b/src/test/java/kr/megaptera/smash/models/NoticeTest.java
@@ -17,9 +17,17 @@ class NoticeTest {
     }
 
     @Test
+    void unchecked() {
+        Notice noticeUnread = Notice.fake(NoticeStatus.unread());
+
+        assertThat(noticeUnread.unchecked()).isTrue();
+    }
+
+    @Test
     void read() {
         Notice notice = Notice.fake(NoticeStatus.unread());
         notice.read();
+
         assertThat(notice.status()).isEqualTo(NoticeStatus.read());
     }
 }

--- a/src/test/java/kr/megaptera/smash/services/GetUnreadNoticeCountServiceTest.java
+++ b/src/test/java/kr/megaptera/smash/services/GetUnreadNoticeCountServiceTest.java
@@ -1,0 +1,51 @@
+package kr.megaptera.smash.services;
+
+import kr.megaptera.smash.dtos.UnreadNoticeCountDto;
+import kr.megaptera.smash.models.Notice;
+import kr.megaptera.smash.models.NoticeStatus;
+import kr.megaptera.smash.repositories.NoticeRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+class GetUnreadNoticeCountServiceTest {
+    private GetUnreadNoticeCountService getUnreadNoticeCountService;
+
+    private NoticeRepository noticeRepository;
+
+    @BeforeEach
+    void setUp() {
+        noticeRepository = mock(NoticeRepository.class);
+
+        getUnreadNoticeCountService
+            = new GetUnreadNoticeCountService(noticeRepository);
+    }
+
+    @Test
+    void countUnreadNotices() {
+        Long currentUserId = 1L;
+
+        List<Notice> notices = List.of(
+            Notice.fake(NoticeStatus.unread()),
+            Notice.fake(NoticeStatus.unread()),
+            Notice.fake(NoticeStatus.unread()),
+            Notice.fake(NoticeStatus.read()),
+            Notice.fake(NoticeStatus.deleted())
+        );
+
+        given(noticeRepository.findAllByUserId(currentUserId))
+            .willReturn(notices);
+
+        UnreadNoticeCountDto unreadNoticeCountDto
+            = getUnreadNoticeCountService.countUnreadNotices(currentUserId);
+
+        assertThat(unreadNoticeCountDto).isNotNull();
+        Long count = unreadNoticeCountDto.getCount();
+        assertThat(count).isEqualTo(3);
+    }
+}


### PR DESCRIPTION
REST API: notice-count?status=unread

REST API 네이밍 선정을 위한 고민: https://stackoverflow.com/questions/43356344/alternatives-of-using-verbs-and-adjectives-in-restful-url

처음에는 notices?status=unread 의 주소로 NoticeController에서 요청을 받게 하려 했으나, path가 같고 query string이 다를 때, 서로 다른 두 개의 controller 메서드로 요청을 받을 수 없었음 (에러 메시지: Ambiguous mapping. Cannot map 'noticeController' method
kr.megaptera.smash.controllers.NoticeController#unreadNoticeCount(Long, String)
to {GET [/notices]}: There is already 'noticeController' bean method)

리소스를 고민했을 때, Notice와는 다른 리소스라고 생각되어 NoticeCountController로 분리 (NoticeCount라는 '숫자' 리소스이지, 'Notice'가 아님!)