### PR TITLE
선택한 알림을 읽은 상태로 변경 요청, 알림 삭제 요청 처리

### DIFF
--- a/src/main/java/kr/megaptera/smash/controllers/NoticeController.java
+++ b/src/main/java/kr/megaptera/smash/controllers/NoticeController.java
@@ -1,14 +1,19 @@
 package kr.megaptera.smash.controllers;
 
+import kr.megaptera.smash.dtos.NoticeIdsRequestDto;
 import kr.megaptera.smash.dtos.NoticesDto;
+import kr.megaptera.smash.services.DeleteNoticesService;
 import kr.megaptera.smash.services.GetNoticesService;
 import kr.megaptera.smash.services.ReadNoticeService;
+import kr.megaptera.smash.services.ReadNoticesService;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,11 +22,18 @@ import org.springframework.web.bind.annotation.RestController;
 public class NoticeController {
     private final GetNoticesService getNoticesService;
     private final ReadNoticeService readNoticeService;
+    private final ReadNoticesService readNoticesService;
+    private final DeleteNoticesService deleteNoticesService;
 
     public NoticeController(GetNoticesService getNoticesService,
-                            ReadNoticeService readNoticeService) {
+                            ReadNoticeService readNoticeService,
+                            ReadNoticesService readNoticesService,
+                            DeleteNoticesService deleteNoticesService
+    ) {
         this.getNoticesService = getNoticesService;
         this.readNoticeService = readNoticeService;
+        this.readNoticesService = readNoticesService;
+        this.deleteNoticesService = deleteNoticesService;
     }
 
     @GetMapping
@@ -37,5 +49,18 @@ public class NoticeController {
         @PathVariable("noticeId") Long targetNoticeId
     ) {
         readNoticeService.readTargetNotice(targetNoticeId);
+    }
+
+    @PatchMapping
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void changeNoticesStatus(
+        @RequestBody NoticeIdsRequestDto noticeIdsRequestDto,
+        @RequestParam(value = "status") String status
+    ) {
+        if (status.equals("read")) {
+            readNoticesService.readTargetNotices(noticeIdsRequestDto.getIds());
+            return;
+        }
+        deleteNoticesService.deleteTargetNotices(noticeIdsRequestDto.getIds());
     }
 }

--- a/src/main/java/kr/megaptera/smash/dtos/NoticeIdsRequestDto.java
+++ b/src/main/java/kr/megaptera/smash/dtos/NoticeIdsRequestDto.java
@@ -1,0 +1,19 @@
+package kr.megaptera.smash.dtos;
+
+import java.util.List;
+
+public class NoticeIdsRequestDto {
+    private List<Long> ids;
+
+    public NoticeIdsRequestDto() {
+
+    }
+
+    public NoticeIdsRequestDto(List<Long> ids) {
+        this.ids = ids;
+    }
+
+    public List<Long> getIds() {
+        return ids;
+    }
+}

--- a/src/main/java/kr/megaptera/smash/models/Notice.java
+++ b/src/main/java/kr/megaptera/smash/models/Notice.java
@@ -83,10 +83,28 @@ public class Notice {
         status = NoticeStatus.read();
     }
 
+    public void deleted() {
+        status = NoticeStatus.deleted();
+    }
+
     public static Notice fake(NoticeStatus status) {
         Long userId = 1L;
         return new Notice(
             1L,
+            userId,
+            new NoticeContents(
+                "알림 제목",
+                "알림 상세 내용"
+            ),
+            status,
+            LocalDateTime.now()
+        );
+    }
+
+    public static Notice fake(Long noticeId, NoticeStatus status) {
+        Long userId = 1L;
+        return new Notice(
+            noticeId,
             userId,
             new NoticeContents(
                 "알림 제목",

--- a/src/main/java/kr/megaptera/smash/services/DeleteNoticesService.java
+++ b/src/main/java/kr/megaptera/smash/services/DeleteNoticesService.java
@@ -1,0 +1,28 @@
+package kr.megaptera.smash.services;
+
+import kr.megaptera.smash.exceptions.NoticeNotFound;
+import kr.megaptera.smash.models.Notice;
+import kr.megaptera.smash.repositories.NoticeRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class DeleteNoticesService {
+    private final NoticeRepository noticeRepository;
+
+    public DeleteNoticesService(NoticeRepository noticeRepository) {
+        this.noticeRepository = noticeRepository;
+    }
+
+    public void deleteTargetNotices(List<Long> noticeIds) {
+        noticeIds.forEach(noticeId -> {
+            Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new NoticeNotFound(noticeId));
+
+            notice.deleted();
+        });
+    }
+}

--- a/src/main/java/kr/megaptera/smash/services/ReadNoticesService.java
+++ b/src/main/java/kr/megaptera/smash/services/ReadNoticesService.java
@@ -1,0 +1,28 @@
+package kr.megaptera.smash.services;
+
+import kr.megaptera.smash.exceptions.NoticeNotFound;
+import kr.megaptera.smash.models.Notice;
+import kr.megaptera.smash.repositories.NoticeRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class ReadNoticesService {
+    private final NoticeRepository noticeRepository;
+
+    public ReadNoticesService(NoticeRepository noticeRepository) {
+        this.noticeRepository = noticeRepository;
+    }
+
+    public void readTargetNotices(List<Long> noticeIds) {
+        noticeIds.forEach(noticeId -> {
+             Notice notice = noticeRepository.findById(noticeId)
+                 .orElseThrow(() -> new NoticeNotFound(noticeId));
+
+             notice.read();
+        });
+    }
+}

--- a/src/test/java/kr/megaptera/smash/controllers/NoticeControllerTest.java
+++ b/src/test/java/kr/megaptera/smash/controllers/NoticeControllerTest.java
@@ -3,24 +3,25 @@ package kr.megaptera.smash.controllers;
 import kr.megaptera.smash.config.MockMvcEncoding;
 import kr.megaptera.smash.dtos.NoticeDto;
 import kr.megaptera.smash.dtos.NoticesDto;
-import kr.megaptera.smash.dtos.UnreadNoticeCountDto;
+import kr.megaptera.smash.services.DeleteNoticesService;
 import kr.megaptera.smash.services.GetNoticesService;
-import kr.megaptera.smash.services.GetUnreadNoticeCountService;
 import kr.megaptera.smash.services.ReadNoticeService;
+import kr.megaptera.smash.services.ReadNoticesService;
 import kr.megaptera.smash.utils.JwtUtil;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import java.util.List;
 
-import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -35,6 +36,12 @@ class NoticeControllerTest {
 
     @MockBean
     private ReadNoticeService readNoticeService;
+
+    @MockBean
+    private ReadNoticesService readNoticesService;
+
+    @MockBean
+    private DeleteNoticesService deleteNoticesService;
 
     @SpyBean
     private JwtUtil jwtUtil;
@@ -81,5 +88,39 @@ class NoticeControllerTest {
             .andExpect(MockMvcResultMatchers.status().isNoContent());
 
         verify(readNoticeService).readTargetNotice(targetNoticeId);
+    }
+
+    @Test
+    void readNotices() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.patch("/notices")
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{" +
+                "\"ids\":[" +
+                "{\"id\":1}," +
+                "{\"id\":2}" +
+                "]" +
+                "}")
+                .param("status", "read"))
+            .andExpect(MockMvcResultMatchers.status().isNoContent());
+
+        verify(readNoticesService).readTargetNotices(anyList());
+    }
+
+    @Test
+    void deleteNotices() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.patch("/notices")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{" +
+                    "\"ids\":[" +
+                    "{\"id\":1}," +
+                    "{\"id\":2}" +
+                    "]" +
+                    "}")
+                .param("status", "delete"))
+            .andExpect(MockMvcResultMatchers.status().isNoContent());
+
+        verify(deleteNoticesService).deleteTargetNotices(anyList());
     }
 }

--- a/src/test/java/kr/megaptera/smash/models/NoticeTest.java
+++ b/src/test/java/kr/megaptera/smash/models/NoticeTest.java
@@ -30,4 +30,17 @@ class NoticeTest {
 
         assertThat(notice.status()).isEqualTo(NoticeStatus.read());
     }
+
+    @Test
+    void deleted() {
+        Notice noticeUnread = Notice.fake(NoticeStatus.unread());
+        noticeUnread.deleted();
+
+        assertThat(noticeUnread.status()).isEqualTo(NoticeStatus.deleted());
+
+        Notice noticeRead = Notice.fake(NoticeStatus.read());
+        noticeRead.deleted();
+
+        assertThat(noticeRead.status()).isEqualTo(NoticeStatus.deleted());
+    }
 }

--- a/src/test/java/kr/megaptera/smash/services/DeleteNoticesServiceTest.java
+++ b/src/test/java/kr/megaptera/smash/services/DeleteNoticesServiceTest.java
@@ -1,0 +1,73 @@
+package kr.megaptera.smash.services;
+
+import kr.megaptera.smash.exceptions.NoticeNotFound;
+import kr.megaptera.smash.models.Notice;
+import kr.megaptera.smash.models.NoticeStatus;
+import kr.megaptera.smash.repositories.NoticeRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+class DeleteNoticesServiceTest {
+    private DeleteNoticesService deleteNoticesService;
+
+    private NoticeRepository noticeRepository;
+
+    @BeforeEach
+    void setUp() {
+        noticeRepository = mock(NoticeRepository.class);
+
+        deleteNoticesService = new DeleteNoticesService(noticeRepository);
+    }
+
+    @Test
+    void deleteTargetNotices() {
+        Long noticeId1 = 3L;
+        Long noticeId2 = 4L;
+        Notice notice1 = spy(Notice.fake(noticeId1, NoticeStatus.unread()));
+        Notice notice2 = spy(Notice.fake(noticeId2, NoticeStatus.read()));
+
+        given(noticeRepository.findById(noticeId1))
+            .willReturn(Optional.of(notice1));
+        given(noticeRepository.findById(noticeId2))
+            .willReturn(Optional.of(notice2));
+
+        List<Long> noticeIds = List.of(
+            noticeId1,
+            noticeId2
+        );
+
+        deleteNoticesService.deleteTargetNotices(noticeIds);
+
+        verify(noticeRepository).findById(noticeId1);
+        verify(noticeRepository).findById(noticeId2);
+        verify(notice1).deleted();
+        verify(notice2).deleted();
+    }
+
+    @Test
+    void noticeNotFound() {
+        Long noticeId1 = 234L;
+        Long noticeId2 = 567L;
+
+        given(noticeRepository.findById(noticeId1))
+            .willThrow(NoticeNotFound.class);
+
+        List<Long> noticeIds = List.of(
+            noticeId1,
+            noticeId2
+        );
+
+        assertThrows(NoticeNotFound.class, () -> {
+            deleteNoticesService.deleteTargetNotices(noticeIds);
+        });
+    }
+}

--- a/src/test/java/kr/megaptera/smash/services/ReadNoticesServiceTest.java
+++ b/src/test/java/kr/megaptera/smash/services/ReadNoticesServiceTest.java
@@ -1,0 +1,73 @@
+package kr.megaptera.smash.services;
+
+import kr.megaptera.smash.exceptions.NoticeNotFound;
+import kr.megaptera.smash.models.Notice;
+import kr.megaptera.smash.models.NoticeStatus;
+import kr.megaptera.smash.repositories.NoticeRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+class ReadNoticesServiceTest {
+    private ReadNoticesService readNoticesService;
+
+    private NoticeRepository noticeRepository;
+
+    @BeforeEach
+    void setUp() {
+        noticeRepository = mock(NoticeRepository.class);
+
+        readNoticesService = new ReadNoticesService(noticeRepository);
+    }
+
+    @Test
+    void readTargetNotices() {
+        Long noticeId1 = 1L;
+        Long noticeId2 = 2L;
+        Notice notice1 = spy(Notice.fake(noticeId1, NoticeStatus.unread()));
+        Notice notice2 = spy(Notice.fake(noticeId2, NoticeStatus.unread()));
+
+        given(noticeRepository.findById(noticeId1))
+            .willReturn(Optional.of(notice1));
+        given(noticeRepository.findById(noticeId2))
+            .willReturn(Optional.of(notice2));
+
+        List<Long> noticeIds = List.of(
+            noticeId1,
+            noticeId2
+        );
+
+        readNoticesService.readTargetNotices(noticeIds);
+
+        verify(noticeRepository).findById(noticeId1);
+        verify(noticeRepository).findById(noticeId2);
+        verify(notice1).read();
+        verify(notice2).read();
+    }
+
+    @Test
+    void noticeNotFound() {
+        Long noticeId1 = 996L;
+        Long noticeId2 = 2222L;
+
+        given(noticeRepository.findById(noticeId1))
+            .willThrow(NoticeNotFound.class);
+
+        List<Long> noticeIds = List.of(
+            noticeId1,
+            noticeId2
+        );
+
+        assertThrows(NoticeNotFound.class, () -> {
+            readNoticesService.readTargetNotices(noticeIds);
+        });
+    }
+}


### PR DESCRIPTION
알림의 상태 전환
REST API: PATCH /notices?status={status}
Request Body: "noticeIds": ["Long"]
Controller: NoticeController

status: read -> ReadNoticesService
status: delete -> deleteNoticesService