### PR TITLE
프론트엔드 응답 수신 형식과 맞지 않는 예외 처리 핸들러 수정

### DIFF
--- a/src/main/java/kr/megaptera/smash/controllers/ApplicantController.java
+++ b/src/main/java/kr/megaptera/smash/controllers/ApplicantController.java
@@ -1,9 +1,13 @@
 package kr.megaptera.smash.controllers;
 
 import kr.megaptera.smash.dtos.RegistersProcessingDto;
+import kr.megaptera.smash.exceptions.UserNotFound;
 import kr.megaptera.smash.services.GetProcessingRegisterService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -18,6 +22,12 @@ public class ApplicantController {
     public RegistersProcessingDto applicants(
         @PathVariable("gameId") Long targetGameId
     ) {
-        return getProcessingRegisterService.findApplicants(targetGameId);
+        return getProcessingRegisterService.findProcessingRegisters(targetGameId);
+    }
+
+    @ExceptionHandler(UserNotFound.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public String userNotFound() {
+        return "User Not Found";
     }
 }

--- a/src/main/java/kr/megaptera/smash/controllers/GameController.java
+++ b/src/main/java/kr/megaptera/smash/controllers/GameController.java
@@ -1,11 +1,16 @@
 package kr.megaptera.smash.controllers;
 
 import kr.megaptera.smash.dtos.GameDetailDto;
+import kr.megaptera.smash.exceptions.GameNotFound;
+import kr.megaptera.smash.exceptions.UserNotFound;
 import kr.megaptera.smash.services.GetGameService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -23,5 +28,17 @@ public class GameController {
         @PathVariable("postId") Long targetPostId
     ) {
         return getGameService.findTargetGame(currentUserId, targetPostId);
+    }
+
+    @ExceptionHandler(UserNotFound.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public String userNotFound() {
+        return "User Not Found";
+    }
+
+    @ExceptionHandler(GameNotFound.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public String gameNotFound() {
+        return "Game Not Found";
     }
 }

--- a/src/main/java/kr/megaptera/smash/controllers/MemberController.java
+++ b/src/main/java/kr/megaptera/smash/controllers/MemberController.java
@@ -1,9 +1,13 @@
 package kr.megaptera.smash.controllers;
 
 import kr.megaptera.smash.dtos.RegistersAcceptedDto;
+import kr.megaptera.smash.exceptions.UserNotFound;
 import kr.megaptera.smash.services.GetAcceptedRegisterService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -19,5 +23,11 @@ public class MemberController {
         @PathVariable("gameId") Long targetGameId
     ) {
         return getAcceptedRegisterService.findAcceptedRegisters(targetGameId);
+    }
+
+    @ExceptionHandler(UserNotFound.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public String userNotFound() {
+        return "User Not Found";
     }
 }

--- a/src/main/java/kr/megaptera/smash/controllers/PlaceController.java
+++ b/src/main/java/kr/megaptera/smash/controllers/PlaceController.java
@@ -1,10 +1,14 @@
 package kr.megaptera.smash.controllers;
 
 import kr.megaptera.smash.dtos.PlaceDto;
+import kr.megaptera.smash.exceptions.PlaceNotFound;
 import kr.megaptera.smash.services.GetPlaceService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -21,5 +25,11 @@ public class PlaceController {
         @PathVariable Long placeId
     ) {
         return getPlaceService.getTargetPlace(placeId);
+    }
+
+    @ExceptionHandler(PlaceNotFound.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public String placeNotFound() {
+        return "Place Not Found";
     }
 }

--- a/src/main/java/kr/megaptera/smash/controllers/PostController.java
+++ b/src/main/java/kr/megaptera/smash/controllers/PostController.java
@@ -71,18 +71,6 @@ public class PostController {
         @RequestBody PostCreateRequestDto postCreateRequestDto,
         BindingResult bindingResult
     ) {
-        System.out.println(postCreateRequestDto.getPost().getDetail());
-        System.out.println(postCreateRequestDto.getPlace().getName());
-        System.out.println(postCreateRequestDto.getExercise().getName());
-        System.out.println(postCreateRequestDto.getGame().getDate());
-        System.out.println(postCreateRequestDto.getGame().getEndHour());
-        System.out.println(postCreateRequestDto.getGame().getEndMinute());
-        System.out.println(postCreateRequestDto.getGame().getEndTimeAmPm());
-        System.out.println(postCreateRequestDto.getGame().getStartHour());
-        System.out.println(postCreateRequestDto.getGame().getStartMinute());
-        System.out.println(postCreateRequestDto.getGame().getStartTimeAmPm());
-        System.out.println(postCreateRequestDto.getGame().getTargetMemberCount());
-
         if (bindingResult.hasErrors()) {
             List<String> errorMessages = bindingResult.getAllErrors()
                 .stream()

--- a/src/main/java/kr/megaptera/smash/controllers/RegisterController.java
+++ b/src/main/java/kr/megaptera/smash/controllers/RegisterController.java
@@ -4,7 +4,9 @@ import kr.megaptera.smash.dtos.RegisterGameResultDto;
 import kr.megaptera.smash.exceptions.AlreadyJoinedGame;
 import kr.megaptera.smash.exceptions.GameIsFull;
 import kr.megaptera.smash.exceptions.GameNotFound;
+import kr.megaptera.smash.exceptions.IsNotRegisterOfCurrentUser;
 import kr.megaptera.smash.exceptions.PostNotFound;
+import kr.megaptera.smash.exceptions.RegisterNotFound;
 import kr.megaptera.smash.exceptions.UserNotFound;
 import kr.megaptera.smash.services.AcceptRegisterService;
 import kr.megaptera.smash.services.CancelRegisterService;
@@ -77,12 +79,6 @@ public class RegisterController {
         return "Game Not Found";
     }
 
-    @ExceptionHandler(PostNotFound.class)
-    @ResponseStatus(HttpStatus.NOT_FOUND)
-    public String postNotFound() {
-        return "Post Not Found";
-    }
-
     @ExceptionHandler(AlreadyJoinedGame.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public String alreadyJoinedGame() {
@@ -93,5 +89,23 @@ public class RegisterController {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public String gameIsFull() {
         return "Game Is Full";
+    }
+
+    @ExceptionHandler(PostNotFound.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public String postNotFound() {
+        return "Post Not Found";
+    }
+
+    @ExceptionHandler(RegisterNotFound.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public String registerNotFound() {
+        return "Register Not Found";
+    }
+
+    @ExceptionHandler(IsNotRegisterOfCurrentUser.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public String isNotRegisterOfCurrentUser() {
+        return "Is Not Register Of Current User";
     }
 }

--- a/src/main/java/kr/megaptera/smash/exceptions/IsNotRegisterOfCurrentUser.java
+++ b/src/main/java/kr/megaptera/smash/exceptions/IsNotRegisterOfCurrentUser.java
@@ -1,7 +1,7 @@
 package kr.megaptera.smash.exceptions;
 
-public class RegisterIdAndUserIdNotMatch extends RuntimeException {
-    public RegisterIdAndUserIdNotMatch() {
+public class IsNotRegisterOfCurrentUser extends RuntimeException {
+    public IsNotRegisterOfCurrentUser() {
         super("신청 번호와 사용자 번호가 일치하지 않습니다.");
     }
 }

--- a/src/main/java/kr/megaptera/smash/models/Post.java
+++ b/src/main/java/kr/megaptera/smash/models/Post.java
@@ -148,6 +148,10 @@ public class Post {
         return user != null && userId.equals(user.id());
     }
 
+    public Boolean isAuthor(Long userId) {
+        return this.userId.equals(userId);
+    }
+
     public void addHits() {
         hits = new PostHits(this.hits.value() + 1);
     }

--- a/src/main/java/kr/megaptera/smash/models/Register.java
+++ b/src/main/java/kr/megaptera/smash/models/Register.java
@@ -74,6 +74,10 @@ public class Register {
         return user != null && userId.equals(user.id());
     }
 
+    public boolean match(Long userId) {
+        return this.userId.equals(userId);
+    }
+
     public boolean active() {
         return status.equals(RegisterStatus.processing())
             || status.equals(RegisterStatus.accepted());

--- a/src/main/java/kr/megaptera/smash/models/User.java
+++ b/src/main/java/kr/megaptera/smash/models/User.java
@@ -117,8 +117,9 @@ public class User {
     }
 
     public static User fake(String name, String account) {
+        Long userId = 1L;
         return new User(
-            1L,
+            userId,
             new UserAccount(account),
             new UserPersonalInformation(
                 name, "여성", "01000000000"
@@ -128,12 +129,12 @@ public class User {
 
     public static List<User> fakes(long generationCount) {
         List<User> users = new ArrayList<>();
-        for (long id = 1; id <= generationCount; id += 1) {
+        for (long userId = 1; userId <= generationCount; userId += 1) {
             User user = new User(
-                id,
-                new UserAccount("account" + id),
+                userId,
+                new UserAccount("account" + userId),
                 new UserPersonalInformation(
-                    "사용자" + id, "여성", "01000000000"
+                    "사용자" + userId, "여성", "01000000000"
                 )
             );
             users.add(user);

--- a/src/main/java/kr/megaptera/smash/services/CancelRegisterService.java
+++ b/src/main/java/kr/megaptera/smash/services/CancelRegisterService.java
@@ -1,6 +1,6 @@
 package kr.megaptera.smash.services;
 
-import kr.megaptera.smash.exceptions.RegisterIdAndUserIdNotMatch;
+import kr.megaptera.smash.exceptions.IsNotRegisterOfCurrentUser;
 import kr.megaptera.smash.exceptions.RegisterNotFound;
 import kr.megaptera.smash.models.Register;
 import kr.megaptera.smash.repositories.RegisterRepository;
@@ -21,8 +21,8 @@ public class CancelRegisterService {
             = registerRepository.findById(registerId)
             .orElseThrow(RegisterNotFound::new);
 
-        if (!register.userId().equals(accessedUserId)) {
-            throw new RegisterIdAndUserIdNotMatch();
+        if (!register.match(accessedUserId)) {
+            throw new IsNotRegisterOfCurrentUser();
         }
 
         register.cancel();

--- a/src/main/java/kr/megaptera/smash/services/DeletePostService.java
+++ b/src/main/java/kr/megaptera/smash/services/DeletePostService.java
@@ -30,7 +30,7 @@ public class DeletePostService {
         Post post = postRepository.findById(targetPostId)
             .orElseThrow(() -> new PostNotFound(targetPostId));
 
-        if (!post.userId().equals(accessedUserId)) {
+        if (!post.isAuthor(accessedUserId)) {
             throw new UserIsNotAuthor();
         }
 

--- a/src/main/java/kr/megaptera/smash/services/GetPostService.java
+++ b/src/main/java/kr/megaptera/smash/services/GetPostService.java
@@ -27,7 +27,7 @@ public class GetPostService {
         Post post = postRepository.findById(targetPostId)
             .orElseThrow(PostNotFound::new);
 
-        User currentUser= currentUserId == null
+        User currentUser = currentUserId == null
             ? null
             : userRepository.findById(currentUserId)
             .orElseThrow(() -> new UserNotFound(currentUserId));

--- a/src/main/java/kr/megaptera/smash/services/GetProcessingRegisterService.java
+++ b/src/main/java/kr/megaptera/smash/services/GetProcessingRegisterService.java
@@ -24,7 +24,7 @@ public class GetProcessingRegisterService {
         this.userRepository = userRepository;
     }
 
-    public RegistersProcessingDto findApplicants(Long targetGameId) {
+    public RegistersProcessingDto findProcessingRegisters(Long targetGameId) {
         List<Register> registers = registerRepository.findAllByGameId(targetGameId);
 
         List<RegisterProcessingDto> registerProcessingDtos

--- a/src/test/java/kr/megaptera/smash/controllers/ApplicantControllerTest.java
+++ b/src/test/java/kr/megaptera/smash/controllers/ApplicantControllerTest.java
@@ -2,6 +2,7 @@ package kr.megaptera.smash.controllers;
 
 import kr.megaptera.smash.dtos.RegisterProcessingDto;
 import kr.megaptera.smash.dtos.RegistersProcessingDto;
+import kr.megaptera.smash.exceptions.UserNotFound;
 import kr.megaptera.smash.models.Register;
 import kr.megaptera.smash.models.User;
 import kr.megaptera.smash.services.GetProcessingRegisterService;
@@ -53,7 +54,7 @@ class ApplicantControllerTest {
 
     @Test
     void applicants() throws Exception {
-        given(getProcessingRegisterService.findApplicants(gameId))
+        given(getProcessingRegisterService.findProcessingRegisters(gameId))
             .willReturn(registersProcessingDto);
 
         mockMvc.perform(MockMvcRequestBuilders.get("/games/1/applicants"))
@@ -61,5 +62,14 @@ class ApplicantControllerTest {
             .andExpect(MockMvcResultMatchers.content().string(
                 containsString("\"phoneNumber\":\"010-0000-0000\"")
             ));
+    }
+
+    @Test
+    void applicantsWithUserNotFound() throws Exception {
+        given(getProcessingRegisterService.findProcessingRegisters(gameId))
+            .willThrow(UserNotFound.class);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/games/1/applicants"))
+            .andExpect(MockMvcResultMatchers.status().isNotFound());
     }
 }

--- a/src/test/java/kr/megaptera/smash/controllers/GameControllerTest.java
+++ b/src/test/java/kr/megaptera/smash/controllers/GameControllerTest.java
@@ -2,6 +2,8 @@ package kr.megaptera.smash.controllers;
 
 import kr.megaptera.smash.config.MockMvcEncoding;
 import kr.megaptera.smash.dtos.GameDetailDto;
+import kr.megaptera.smash.exceptions.GameNotFound;
+import kr.megaptera.smash.exceptions.UserNotFound;
 import kr.megaptera.smash.models.Game;
 import kr.megaptera.smash.models.Register;
 import kr.megaptera.smash.services.GetGameService;
@@ -79,6 +81,37 @@ class GameControllerTest {
             ))
             .andExpect(MockMvcResultMatchers.content().string(
                 containsString("\"registerStatus\":\"none\"")
+            ))
+        ;
+    }
+
+    @Test
+    void gameWithUserNotFound() throws Exception {
+        Long wrongUserId = 994L;
+        String wrongToken = jwtUtil.encode(wrongUserId);
+
+        given(getGameService.findTargetGame(wrongUserId, targetPostId))
+            .willThrow(UserNotFound.class);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/games/posts/1")
+                .header("Authorization", "Bearer " + wrongToken))
+            .andExpect(MockMvcResultMatchers.status().isNotFound())
+            .andExpect(MockMvcResultMatchers.content().string(
+                containsString("User Not Found")
+            ))
+        ;
+    }
+
+    @Test
+    void gameWithGameNotFound() throws Exception {
+        given(getGameService.findTargetGame(userId, targetPostId))
+            .willThrow(GameNotFound.class);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/games/posts/1")
+                .header("Authorization", "Bearer " + token))
+            .andExpect(MockMvcResultMatchers.status().isNotFound())
+            .andExpect(MockMvcResultMatchers.content().string(
+                containsString("Game Not Found")
             ))
         ;
     }

--- a/src/test/java/kr/megaptera/smash/controllers/MemberControllerTest.java
+++ b/src/test/java/kr/megaptera/smash/controllers/MemberControllerTest.java
@@ -3,6 +3,7 @@ package kr.megaptera.smash.controllers;
 import kr.megaptera.smash.config.MockMvcEncoding;
 import kr.megaptera.smash.dtos.RegisterAcceptedDto;
 import kr.megaptera.smash.dtos.RegistersAcceptedDto;
+import kr.megaptera.smash.exceptions.UserNotFound;
 import kr.megaptera.smash.models.Register;
 import kr.megaptera.smash.models.User;
 import kr.megaptera.smash.services.GetAcceptedRegisterService;
@@ -64,5 +65,14 @@ class MemberControllerTest {
             .andExpect(MockMvcResultMatchers.content().string(
                 containsString("\"phoneNumber\":\"010-0000-0000\"")
             ));
+    }
+
+    @Test
+    void membersWithUserNotFound() throws Exception {
+        given(getAcceptedRegisterService.findAcceptedRegisters(gameId))
+            .willThrow(UserNotFound.class);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/games/1/members"))
+            .andExpect(MockMvcResultMatchers.status().isNotFound());
     }
 }

--- a/src/test/java/kr/megaptera/smash/controllers/PlaceControllerTest.java
+++ b/src/test/java/kr/megaptera/smash/controllers/PlaceControllerTest.java
@@ -2,6 +2,7 @@ package kr.megaptera.smash.controllers;
 
 import kr.megaptera.smash.config.MockMvcEncoding;
 import kr.megaptera.smash.dtos.PlaceDto;
+import kr.megaptera.smash.exceptions.PlaceNotFound;
 import kr.megaptera.smash.models.Place;
 import kr.megaptera.smash.services.GetPlaceService;
 import org.junit.jupiter.api.Test;
@@ -37,5 +38,15 @@ class PlaceControllerTest {
                 containsString("운동 장소 이름")
             ))
         ;
+    }
+
+    @Test
+    void placeNotFound() throws Exception {
+        Long wrongPlaceId = 2277L;
+        given(getPlaceService.getTargetPlace(wrongPlaceId))
+            .willThrow(PlaceNotFound.class);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/places/2277"))
+            .andExpect(MockMvcResultMatchers.status().isNotFound());
     }
 }

--- a/src/test/java/kr/megaptera/smash/controllers/PostControllerTest.java
+++ b/src/test/java/kr/megaptera/smash/controllers/PostControllerTest.java
@@ -329,7 +329,7 @@ class PostControllerTest {
 
         ExerciseForPostCreateRequestDto wrongExerciseForPostCreateRequestDto
             = new ExerciseForPostCreateRequestDto(
-            ""
+            blankGameExercise
         );
         given(createPostService.createPost(
             userId,
@@ -383,7 +383,7 @@ class PostControllerTest {
             = new GameForPostCreateRequestDto(
             "2022-12-22T00:00:00.000Z",
             "am", "11", "30", "pm", "04", "00",
-            null
+            nullGameTargetMemberCount
         );
         given(createPostService.createPost(
             userId,

--- a/src/test/java/kr/megaptera/smash/models/PostTest.java
+++ b/src/test/java/kr/megaptera/smash/models/PostTest.java
@@ -8,12 +8,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class PostTest {
     @Test
-    void isAuthor() {
+    void isAuthorWithUser() {
         Long postId = 1L;
         Long userId = 1L;
         Post post = Post.fake(postId);
         User user = User.fake(userId);
         assertThat(post.isAuthor(user)).isTrue();
+    }
+
+    @Test
+    void isAuthorWithUserId() {
+        Long postId = 1L;
+        Long userId = 1L;
+        Post post = Post.fake(postId);
+        assertThat(post.isAuthor(userId)).isTrue();
     }
 
     @Test

--- a/src/test/java/kr/megaptera/smash/models/RegisterTest.java
+++ b/src/test/java/kr/megaptera/smash/models/RegisterTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class RegisterTest {
     @Test
-    void match() {
+    void matchWithUser() {
         Long userId = 1L;
         Long gameId = 1L;
 
@@ -18,6 +18,18 @@ class RegisterTest {
             .isTrue();
         Long wrongUserId = 9999L;
         assertThat(Register.fake(wrongUserId, gameId).match(user))
+            .isFalse();
+    }
+
+    @Test
+    void matchWithUserId() {
+        Long userId = 1L;
+        Long gameId = 1L;
+
+        assertThat(Register.fake(userId, gameId).match(userId))
+            .isTrue();
+        Long wrongUserId = 9999L;
+        assertThat(Register.fake(userId, gameId).match(wrongUserId))
             .isFalse();
     }
 

--- a/src/test/java/kr/megaptera/smash/services/GetAcceptedRegisterServiceTest.java
+++ b/src/test/java/kr/megaptera/smash/services/GetAcceptedRegisterServiceTest.java
@@ -1,6 +1,7 @@
 package kr.megaptera.smash.services;
 
 import kr.megaptera.smash.dtos.RegistersAcceptedDto;
+import kr.megaptera.smash.exceptions.UserNotFound;
 import kr.megaptera.smash.models.Register;
 import kr.megaptera.smash.models.User;
 import kr.megaptera.smash.repositories.RegisterRepository;
@@ -12,8 +13,10 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 class GetAcceptedRegisterServiceTest {
     private GetAcceptedRegisterService getAcceptedRegisterService;
@@ -30,7 +33,7 @@ class GetAcceptedRegisterServiceTest {
     }
 
     @Test
-    void findTargetMembers() {
+    void findMembers() {
         Long targetGameId = 1L;
         List<Register> members = Register.fakesAccepted(2, targetGameId);
         List<User> users = User.fakes(2);
@@ -47,5 +50,27 @@ class GetAcceptedRegisterServiceTest {
 
         assertThat(registersAcceptedDto).isNotNull();
         assertThat(registersAcceptedDto.getMembers().size()).isEqualTo(2);
+    }
+
+    @Test
+    void findMembersWithUserNotFound() {
+        Long targetGameId = 1L;
+        List<Register> members = Register.fakesAccepted(2, targetGameId);
+        User user = User.fake("사용자 이름", "username12");
+
+        given(registerRepository.findAllByGameId(targetGameId))
+            .willReturn(members);
+        given(userRepository.findById(members.get(0).userId()))
+            .willReturn(Optional.of(user));
+        given(userRepository.findById(members.get(1).userId()))
+            .willThrow(UserNotFound.class);
+
+        assertThrows(UserNotFound.class, () -> {
+            getAcceptedRegisterService.findAcceptedRegisters(targetGameId);
+        });
+
+        verify(registerRepository).findAllByGameId(targetGameId);
+        verify(userRepository).findById(members.get(0).userId());
+        verify(userRepository).findById(members.get(1).userId());
     }
 }

--- a/src/test/java/kr/megaptera/smash/services/GetGameServiceTest.java
+++ b/src/test/java/kr/megaptera/smash/services/GetGameServiceTest.java
@@ -1,6 +1,8 @@
 package kr.megaptera.smash.services;
 
 import kr.megaptera.smash.dtos.GameDetailDto;
+import kr.megaptera.smash.exceptions.GameNotFound;
+import kr.megaptera.smash.exceptions.UserNotFound;
 import kr.megaptera.smash.models.Exercise;
 import kr.megaptera.smash.models.Game;
 import kr.megaptera.smash.models.GameDateTime;
@@ -20,6 +22,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -121,5 +124,35 @@ class GetGameServiceTest {
         assertThat(gameDetailDto.getRegisterStatus()).isEqualTo("none");
 
         verify(userRepository, never()).findById(any(Long.class));
+    }
+
+    @Test
+    void findTargetGameWithUserNotFound() {
+        Long wrongUserId = 996L;
+        Long targetPostId = 1L;
+
+        given(userRepository.findById(wrongUserId))
+            .willThrow(UserNotFound.class);
+
+        assertThrows(UserNotFound.class, () -> {
+            getGameService.findTargetGame(wrongUserId, targetPostId);
+        });
+
+        verify(userRepository).findById(wrongUserId);
+    }
+
+    @Test
+    void findTargetGameWithGameNotFound() {
+        Long currentUserId = null;
+        Long targetPostId = 2432L;
+
+        given(gameRepository.findByPostId(targetPostId))
+            .willThrow(GameNotFound.class);
+
+        assertThrows(GameNotFound.class, () -> {
+            getGameService.findTargetGame(currentUserId, targetPostId);
+        });
+
+        verify(gameRepository).findByPostId(targetPostId);
     }
 }

--- a/src/test/java/kr/megaptera/smash/services/GetPlaceServiceTest.java
+++ b/src/test/java/kr/megaptera/smash/services/GetPlaceServiceTest.java
@@ -1,6 +1,7 @@
 package kr.megaptera.smash.services;
 
 import kr.megaptera.smash.dtos.PlaceDto;
+import kr.megaptera.smash.exceptions.PlaceNotFound;
 import kr.megaptera.smash.models.Place;
 import kr.megaptera.smash.repositories.PlaceRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -9,8 +10,10 @@ import org.junit.jupiter.api.Test;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 class GetPlaceServiceTest {
     private GetPlaceService getPlaceService;
@@ -36,5 +39,19 @@ class GetPlaceServiceTest {
 
         assertThat(placeDto).isNotNull();
         assertThat(placeDto.getName()).isEqualTo("장소 이름");
+    }
+
+    @Test
+    void findTargetPlaceWithPlaceNotFound() {
+        Long wrongPlaceId = 9922L;
+
+        given(placeRepository.findById(wrongPlaceId))
+            .willThrow(PlaceNotFound.class);
+
+        assertThrows(PlaceNotFound.class, () -> {
+            getPlaceService.getTargetPlace(wrongPlaceId);
+        });
+
+        verify(placeRepository).findById(wrongPlaceId);
     }
 }

--- a/src/test/java/kr/megaptera/smash/services/RejectRegisterServiceTest.java
+++ b/src/test/java/kr/megaptera/smash/services/RejectRegisterServiceTest.java
@@ -1,5 +1,6 @@
 package kr.megaptera.smash.services;
 
+import kr.megaptera.smash.exceptions.RegisterNotFound;
 import kr.megaptera.smash.models.Register;
 import kr.megaptera.smash.models.RegisterStatus;
 import kr.megaptera.smash.repositories.RegisterRepository;
@@ -8,6 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -27,7 +29,7 @@ class RejectRegisterServiceTest {
     }
 
     @Test
-    void makeGameApplicantToMember() {
+    void rejectRegister() {
         Long registerId = 12L;
         Long userId = 1L;
         Register register = spy(new Register(
@@ -44,5 +46,19 @@ class RejectRegisterServiceTest {
 
         verify(registerRepository).findById(registerId);
         verify(register).reject();
+    }
+
+    @Test
+    void rejectRegisterFailedWithRegisterNotFound() {
+        Long wrongRegisterId = 999L;
+
+        given(registerRepository.findById(wrongRegisterId))
+            .willThrow(RegisterNotFound.class);
+
+        assertThrows(RegisterNotFound.class, () -> {
+            rejectRegisterService.rejectRegister(wrongRegisterId);
+        });
+
+        verify(registerRepository).findById(wrongRegisterId);
     }
 }


### PR DESCRIPTION
https://github.com/hsjkdss228/smash-frontend/pull/61

프론트엔드 Store의 단위 테스트를 수정하면서 수신해야 하는 예외 처리 핸들러가 Controller에 없는 경우에는 예외 처리 핸들러를 추가하고, 테스트로 예외처리를 검증하지 않고 있는 경우에는 테스트를 추가